### PR TITLE
Fix race condition between CommManager and neptune-notebooks

### DIFF
--- a/packages/neptune-extension/config/webpack.nbextension.js
+++ b/packages/neptune-extension/config/webpack.nbextension.js
@@ -45,10 +45,9 @@ module.exports = function ({ mode, project }) {
     externals: {
       jquery: 'jQuery',
       'base/js/namespace': 'base/js/namespace',
-      'base/js/events': 'base/js/events',
-      'base/js/dialog': 'base/js/dialog',
       'contents': 'contents',
       'services/config': 'services/config',
+      'services/kernels/comm': 'services/kernels/comm',
     },
     // TODO: probably should be depenand of build mode
     devtool: mode === 'development'

--- a/packages/neptune-extension/src/nbextension/utils/notebook.ts
+++ b/packages/neptune-extension/src/nbextension/utils/notebook.ts
@@ -5,9 +5,9 @@ import {
 } from 'types/platform';
 
 import Jupyter from 'base/js/namespace';
+import CommManager from 'services/kernels/comm';
 import JupyterConfig from 'services/config';
 import JupyterContents from 'contents';
-
 
 class Notebook implements PlatformNotebook {
 
@@ -29,7 +29,7 @@ class Notebook implements PlatformNotebook {
       common_config: commonConfig,
     });
   };
-  
+
   async saveWorkingCopyAndGetContent() {
     Jupyter.notebook.save_checkpoint();
 
@@ -63,6 +63,14 @@ class Notebook implements PlatformNotebook {
   }
 
   async registerNeptuneMessageListener(callback: (msg: NeptuneClientMsg) => void) {
+    /**
+     * Usage of "CommManager" here is a workaround.
+     * We have to "use" it somehow to point out to webpack to include it as runtime dependency in a final bundle.
+     */
+    if (CommManager == null) {
+      return;
+    }
+
     Jupyter.notebook.kernel.comm_manager.register_target(
       'neptune_comm',
       (comm: NbComm) => {

--- a/packages/neptune-extension/src/types/jupyter.d.ts
+++ b/packages/neptune-extension/src/types/jupyter.d.ts
@@ -11,6 +11,10 @@ declare module 'base/js/namespace' {
   export default Jupyter;
 }
 
+declare module 'services/kernels/comm' {
+  export default {};
+}
+
 interface NbJupyter {
   keyboard_manager: NbKeyboardManager
   toolbar: NbToolbar


### PR DESCRIPTION
Problem appeared on combination of:
 * Jupyter Notebook
 * big notebook
 * slow connection to the Jupyter serve

We need to include `'services/kernels/comm'` explicite as a runtime dependency so Jupyter knows when to safely load our extension.