### PR TITLE
Move deployment to pypi/npm to Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 - '2.7'
 - '3.6'
 - '3.7'
+- '3.8'
 
 cache:
   pip: true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]
+if [[ "$TRAVIS_PYTHON_VERSION" == "3.8" ]]
 then
     # pypi package
     twine upload dist/*.tar.gz


### PR DESCRIPTION
There is a bug in twine that causes it to not install dependencies properly, which leads to failing deployment.

This PR is an attempt to work around this by moving to Python 3.8 for deployment where the library in question is a part of standard Python lib.

Relevant links:
https://github.com/pypa/twine/issues/729
https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/28