### PR TITLE
Add support for new business domain

### DIFF
--- a/packages/neptune-extension/src/api-spec/backend-swagger.json
+++ b/packages/neptune-extension/src/api-spec/backend-swagger.json
@@ -7,7 +7,9 @@
     "description" : "",
     "termsOfService" : "",
     "contact" : {
-      "name" : ""
+      "name" : "",
+      "url" : "",
+      "email" : ""
     },
     "license" : {
       "name" : "",
@@ -15,654 +17,60 @@
     }
   },
   "paths" : {
-    "/api/backend/v1/projects/{projectIdentifier}/members" : {
-      "get" : {
-        "operationId" : "listProjectMembers",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ProjectMemberDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "addProjectMember",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "member",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/NewProjectMemberDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectMemberDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organizationId}" : {
-      "put" : {
-        "operationId" : "updateOrganization",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "organizationToUpdate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/OrganizationUpdateDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "deleteOrganization",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/numeric" : {
-      "get" : {
-        "operationId" : "getProjectNumericChannels",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "type" : "string"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/{projectId}" : {
-      "put" : {
-        "operationId" : "updateProject",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "projectToUpdate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ProjectUpdateDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectWithRoleDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
+    "/api/backend/v1/projects" : {
       "delete" : {
         "operationId" : "deleteProject",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}/invoices/past" : {
-      "get" : {
-        "operationId" : "getPastInvoices",
-        "summary" : "",
-        "description" : "Pass-through to Stripe /v1/invoices",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "string"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/login" : {
-      "get" : {
-        "operationId" : "login",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/LoginOrRegisterResponseDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/lastValues" : {
-      "get" : {
-        "operationId" : "getChannelsLastValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ChannelWithValueDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage/download" : {
-      "get" : {
-        "operationId" : "downloadPath",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "pathParam",
+          "name" : "projectIdentifier",
           "required" : true,
           "in" : "query",
           "type" : "string"
-        }, {
-          "name" : "preview",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/system/metrics/{metricId}/values" : {
-      "get" : {
-        "operationId" : "getSystemMetricValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "metricId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "startPoint",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int64"
-        }, {
-          "name" : "endPoint",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int64"
-        }, {
-          "name" : "itemCount",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/SystemMetricValues"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/userProfile" : {
-      "get" : {
-        "operationId" : "getUserProfile",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/UserProfileDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
           "oauth2" : [ ]
         } ]
       },
-      "patch" : {
-        "operationId" : "updateUserProfile",
+      "post" : {
+        "operationId" : "createProject",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "userProfileUpdate",
+          "name" : "projectToCreate",
           "required" : true,
           "in" : "body",
           "schema" : {
-            "$ref" : "#/definitions/UserProfileUpdateDTO"
+            "$ref" : "#/definitions/NewProjectDTO"
           }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/UserProfileDTO"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -672,485 +80,40 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/key" : {
-      "get" : {
-        "operationId" : "generateProjectKey",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "projectName",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        } ],
-        "responses" : {
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/ProjectKeyDTO"
+              "$ref" : "#/definitions/ProjectWithRoleDTO"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage2/experiment/{experimentIdentity}/{resource}/prepareForDownload" : {
-      "post" : {
-        "operationId" : "prepareForDownload",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentIdentity",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "resource",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "path",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/DownloadPrepareRequestDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}/subscription/downgrade" : {
-      "post" : {
-        "operationId" : "downgradeSubscription",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/SubscriptionDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects1/{projectId}/background" : {
-      "put" : {
-        "operationId" : "updateProjectBackground",
-        "summary" : "",
-        "consumes" : [ "multipart/form-data" ],
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "backgroundFile",
-          "required" : true,
-          "in" : "formData",
-          "type" : "file"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Link"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/system" : {
-      "post" : {
-        "operationId" : "createSystemChannel",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChannelParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChannelDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
           "oauth2" : [ ]
         } ]
       },
-      "get" : {
-        "operationId" : "getSystemChannels",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ChannelDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/configInfo" : {
-      "get" : {
-        "operationId" : "configInfoGet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ConfigInfo"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/channel/{channelId}/values" : {
-      "get" : {
-        "operationId" : "deprecatedGetChannelValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "offset",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "limit",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/LimitedChannelValuesDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "deprecatedDeleteChannelValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects" : {
       "get" : {
         "operationId" : "listProjects",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
           "name" : "organizationIdentifier",
+          "required" : false,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "viewAsUser",
           "required" : false,
           "in" : "query",
           "type" : "string"
@@ -1164,16 +127,6 @@
           "required" : false,
           "in" : "query",
           "type" : "string"
-        }, {
-          "name" : "starredByMe",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        }, {
-          "name" : "inExplore",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
         }, {
           "name" : "visibility",
           "required" : false,
@@ -1230,12 +183,56 @@
           "format" : "int32"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/ProjectListDTO"
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "put" : {
+        "operationId" : "updateProject",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "projectToUpdate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ProjectUpdateDTO"
+          }
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -1245,62 +242,23 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createProject",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/NewProjectDTO"
-          }
-        } ],
-        "responses" : {
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/ProjectWithRoleDTO"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -1308,503 +266,44 @@
         } ]
       }
     },
-    "/api/backend/v1/chartSets/{chartSetId}" : {
+    "/api/backend/v1/projects/get" : {
       "get" : {
-        "operationId" : "getChartSet",
+        "operationId" : "getProject",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChartSet"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "put" : {
-        "operationId" : "updateChartSet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "chartSetToUpdate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChartSetParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChartSet"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "deleteChartSet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/organization/{invitationId}/accept" : {
-      "post" : {
-        "operationId" : "acceptOrganizationInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage2/downloadRequests/{id}/download" : {
-      "get" : {
-        "operationId" : "download",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "id",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/aliases" : {
-      "get" : {
-        "operationId" : "listProjectAliases",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/Alias"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createAlias",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "aliasToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/AliasParams"
-          }
-        }, {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Alias"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/lastChannelValues" : {
-      "get" : {
-        "operationId" : "deprecatedGetChannelsLastValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ChannelWithValueDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/userProfile/links" : {
-      "delete" : {
-        "operationId" : "deleteUserProfileLink",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "link",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/LinkDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "addUserProfileLink",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "link",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/UserProfileLinkDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage/details" : {
-      "get" : {
-        "operationId" : "getPathDetails",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "pathParam",
+          "name" : "projectIdentifier",
           "required" : true,
           "in" : "query",
           "type" : "string"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/FileDetails"
+              "$ref" : "#/definitions/ProjectWithRoleDTO"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -1812,349 +311,24 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/uploadTarstream" : {
-      "post" : {
-        "operationId" : "uploadExperimentOutputAsTarstream",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/aliases/{aliasId}" : {
+    "/api/backend/v1/projects/key" : {
       "get" : {
-        "operationId" : "getAlias",
+        "operationId" : "generateProjectKey",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "aliasId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Alias"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "put" : {
-        "operationId" : "updateAlias",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "aliasId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "aliasToUpdate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/AliasParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Alias"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "deleteAlias",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "aliasId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/paths" : {
-      "get" : {
-        "operationId" : "getExperimentPaths",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ExperimentPaths"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/project/{invitationId}/accept" : {
-      "post" : {
-        "operationId" : "acceptProjectInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/users" : {
-      "get" : {
-        "operationId" : "listUsers",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "username",
+          "name" : "organizationId",
           "required" : true,
           "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          },
-          "collectionFormat" : "multi"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/PublicUserProfileDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations/{organizationName}/projects/{projectName}/avatar" : {
-      "get" : {
-        "operationId" : "getProjectAvatar",
-        "summary" : "",
-        "produces" : [ "image/png" ],
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
+          "type" : "string",
+          "format" : "uuid"
         }, {
           "name" : "projectName",
           "required" : true,
-          "in" : "path",
+          "in" : "query",
           "type" : "string"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -2164,37 +338,42 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/authorization/api-token" : {
-      "get" : {
-        "operationId" : "getApiToken",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
-              "type" : "string"
+              "$ref" : "#/definitions/ProjectKeyDTO"
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/projects/leave" : {
+      "post" : {
+        "operationId" : "leaveProject",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -2204,17 +383,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -2222,155 +404,51 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/actions/{actionId}/invoke" : {
+    "/api/backend/v1/projects/members" : {
       "post" : {
-        "operationId" : "invokeAction",
+        "operationId" : "addProjectMember",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "experimentId",
+          "name" : "projectIdentifier",
           "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
+          "in" : "query",
+          "type" : "string"
         }, {
-          "name" : "actionId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "invocationParams",
+          "name" : "member",
           "required" : true,
           "in" : "body",
           "schema" : {
-            "$ref" : "#/definitions/ActionInvocationParams"
+            "$ref" : "#/definitions/NewProjectMemberDTO"
           }
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/ActionInvocationConfirmation"
+              "$ref" : "#/definitions/ProjectMemberDTO"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/trash" : {
-      "post" : {
-        "operationId" : "trashExperiments",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentIds",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "uuid"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/BatchExperimentUpdateResult"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/organization/{invitationId}" : {
-      "delete" : {
-        "operationId" : "revokeOrganizationInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -2378,243 +456,11 @@
         } ]
       },
       "get" : {
-        "operationId" : "getOrganizationInvitation",
+        "operationId" : "listProjectsMembers",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "put" : {
-        "operationId" : "updateOrganizationInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "update",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/OrganizationInvitationUpdateDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organizationIdentifier}/activity/external" : {
-      "get" : {
-        "operationId" : "listOrganizationExternalActivity",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/OrganizationExternalActivityDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/features/{id}/markViewed" : {
-      "post" : {
-        "operationId" : "markFeatureViewed",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "id",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}" : {
-      "get" : {
-        "operationId" : "getCustomer",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/CustomerDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2" : {
-      "get" : {
-        "operationId" : "filterOrganizations",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "ids",
+          "name" : "projectIdentifier",
           "required" : true,
           "in" : "query",
           "type" : "array",
@@ -2622,299 +468,14 @@
             "type" : "string"
           },
           "collectionFormat" : "multi"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/OrganizationDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createOrganization",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/OrganizationCreationParamsDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/actionEvents" : {
-      "get" : {
-        "operationId" : "getActionEvents",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ActionEvent"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}/creditCard" : {
-      "delete" : {
-        "operationId" : "removeCreditCard",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "setCreditCard",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
         }, {
-          "name" : "creditCardToken",
-          "description" : "Stripe Token ID",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/CreditCardTokenDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "get" : {
-        "operationId" : "getCreditCard",
-        "summary" : "",
-        "description" : "Returns a Stripe Source object",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "string"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/channel/{channelId}/csv" : {
-      "get" : {
-        "operationId" : "deprecatedGetChannelValuesCSV",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "gzipped",
+          "name" : "includeInvitations",
+          "default" : "Some(true)",
           "required" : false,
           "in" : "query",
           "type" : "boolean"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -2924,47 +485,8 @@
           "404" : {
             "description" : "Not Found"
           },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
           "408" : {
             "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/users/{username}/avatar" : {
-      "get" : {
-        "operationId" : "getUserAvatar",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "username",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
           },
           "403" : {
             "description" : "Forbidden"
@@ -2972,341 +494,17 @@
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/charts" : {
-      "get" : {
-        "operationId" : "getExperimentCharts",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Charts"
-            }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/system/metrics/values" : {
-      "post" : {
-        "operationId" : "postSystemMetricValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "metricValues",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/SystemMetricValues"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/status" : {
-      "get" : {
-        "operationId" : "statusGet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Status"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/uploadSourceTarstream/{experimentId}" : {
-      "post" : {
-        "operationId" : "uploadExperimentSourceAsTarstream",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/output" : {
-      "post" : {
-        "operationId" : "uploadExperimentOutput",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/executionInfo" : {
-      "get" : {
-        "operationId" : "getExecutionInfo",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ExecutionInfo"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage/ls" : {
-      "get" : {
-        "operationId" : "lsPath",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "pathParam",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "recursive",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
           "200" : {
             "description" : "OK",
             "schema" : {
               "type" : "array",
               "items" : {
-                "$ref" : "#/definitions/FileEntry"
+                "$ref" : "#/definitions/ProjectMembersDTO"
               }
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -3314,629 +512,7 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/system/metrics/csv" : {
-      "get" : {
-        "operationId" : "getSystemMetricsCSV",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "gzipped",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/version" : {
-      "get" : {
-        "operationId" : "versionGet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Version"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/storage/usage" : {
-      "get" : {
-        "operationId" : "storageUsage",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "projectIdentifier",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/StorageUsage"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/uploadTarstream" : {
-      "post" : {
-        "operationId" : "uploadDataAsTarstream",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/{channelId}/values" : {
-      "get" : {
-        "operationId" : "getChannelValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "channelId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "offset",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "limit",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/LimitedChannelValuesDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/userProfile/password" : {
-      "put" : {
-        "operationId" : "changePassword",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "passwordToUpdate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/PasswordChangeDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/PasswordChangeDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/stderr" : {
-      "post" : {
-        "operationId" : "uploadExperimentStderr",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/channels/values" : {
-      "post" : {
-        "operationId" : "deprecatedPostChannelValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelsValues",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/InputChannelValues"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/BatchChannelValueErrorDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organization}" : {
-      "get" : {
-        "operationId" : "getOrganization",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organization",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/ping" : {
-      "post" : {
-        "operationId" : "pingExperiment",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/{projectId}/updateLastViewed" : {
-      "post" : {
-        "operationId" : "updateLastViewed",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}/invoices/upcoming" : {
-      "get" : {
-        "operationId" : "getUpcomingInvoice",
-        "summary" : "",
-        "description" : "Pass-through to Stripe /v1/invoices/upcoming",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "string"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/images/{experimentId}/{channelId}/{filename}" : {
-      "get" : {
-        "operationId" : "getImage",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "filename",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/File"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/{projectIdentifier}/members/{userId}" : {
+    "/api/backend/v1/projects/members/{userId}" : {
       "delete" : {
         "operationId" : "deleteProjectMember",
         "summary" : "",
@@ -3944,7 +520,7 @@
         "parameters" : [ {
           "name" : "projectIdentifier",
           "required" : true,
-          "in" : "path",
+          "in" : "query",
           "type" : "string"
         }, {
           "name" : "userId",
@@ -3953,9 +529,6 @@
           "type" : "string"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -3965,17 +538,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -3989,7 +565,7 @@
         "parameters" : [ {
           "name" : "projectIdentifier",
           "required" : true,
-          "in" : "path",
+          "in" : "query",
           "type" : "string"
         }, {
           "name" : "userId",
@@ -4005,32 +581,32 @@
           }
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/ProjectMemberDTO"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -4038,930 +614,9 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/trash/restore" : {
-      "post" : {
-        "operationId" : "restoreExperiments",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentIds",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "uuid"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/BatchExperimentUpdateResult"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/organization/{organizationName}" : {
+    "/api/backend/v1/projects/membersOf" : {
       "get" : {
-        "operationId" : "listProjectsInOrganization",
-        "summary" : "",
-        "deprecated" : true,
-        "parameters" : [ {
-          "name" : "organizationName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "searchTerm",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "starredByMe",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        }, {
-          "name" : "sortBy",
-          "required" : false,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "sortDirection",
-          "required" : false,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "offset",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "limit",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectListDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/download" : {
-      "get" : {
-        "operationId" : "downloadData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "path",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "preview",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/cli" : {
-      "get" : {
-        "operationId" : "downloadCli",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/File"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "uploadCli",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/newLeaderboard/experiments" : {
-      "get" : {
-        "operationId" : "listExistingExperiments",
-        "summary" : "List experiments in organization",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "after",
-          "required" : false,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "limit",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ExperimentEntryDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/project" : {
-      "post" : {
-        "operationId" : "createProjectInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "newProjectInvitation",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/NewProjectInvitationDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/channels" : {
-      "post" : {
-        "operationId" : "deprecatedCreateChannel",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChannelParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChannelDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/features/{id}" : {
-      "get" : {
-        "operationId" : "getFeature",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "id",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/FeatureDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/backups/{experimentId}" : {
-      "post" : {
-        "operationId" : "uploadExperimentBackups",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/chartSets/{chartSetId}/charts" : {
-      "post" : {
-        "operationId" : "createChart",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "chartToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChartDefinition"
-          }
-        }, {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Chart"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/{projectIdentifier}/leave" : {
-      "post" : {
-        "operationId" : "leaveProject",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organizationName}/avatar" : {
-      "get" : {
-        "operationId" : "getOrganizationAvatar",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/source/{experimentId}" : {
-      "post" : {
-        "operationId" : "uploadExperimentSource",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/values" : {
-      "post" : {
-        "operationId" : "postChannelValues",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelsValues",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/InputChannelValues"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/BatchChannelValueErrorDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments" : {
-      "get" : {
-        "operationId" : "listExperiments",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "groupId",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "states",
-          "required" : true,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/ExperimentState"
-          },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "offset",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        }, {
-          "name" : "limit",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ExperimentsList"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createExperiment",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentCreationParams",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ExperimentCreationParams"
-          }
-        }, {
-          "name" : "X-Neptune-CliVersion",
-          "required" : false,
-          "in" : "header",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Experiment"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/projects/{projectIdentifier}" : {
-      "get" : {
-        "operationId" : "getProject",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectWithRoleDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/tags" : {
-      "get" : {
-        "operationId" : "tagsGet",
+        "operationId" : "listProjectMembers",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
@@ -4971,15 +626,54 @@
           "type" : "string"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "type" : "array",
               "items" : {
-                "type" : "string"
+                "$ref" : "#/definitions/ProjectMemberDTO"
               }
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/projects/metadata" : {
+      "get" : {
+        "operationId" : "getProjectMetadata",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -4989,720 +683,66 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ProjectMetadataDTO"
+            }
           }
         },
         "security" : [ {
           "oauth2" : [ ]
         } ]
-      },
-      "put" : {
-        "operationId" : "updateTags",
+      }
+    },
+    "/api/backend/v1/projects/updateLastViewed" : {
+      "post" : {
+        "operationId" : "updateLastViewed",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "updateTagsParams",
+          "name" : "projectId",
           "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/UpdateTagsParams"
-          }
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data" : {
-      "get" : {
-        "operationId" : "lsData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "pathParam",
-          "required" : false,
-          "in" : "query",
-          "type" : "string"
-        }, {
-          "name" : "recursive",
-          "required" : false,
-          "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/FileEntry"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "rmData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "pathParam",
-          "required" : true,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "recursive",
-          "required" : true,
-          "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "mkdirData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "pathParam",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationId}/account" : {
-      "get" : {
-        "operationId" : "getOrganizationAccount",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationAccountDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/markCompleted" : {
-      "post" : {
-        "operationId" : "markExperimentCompleted",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "completedExperimentParams",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/CompletedExperimentParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Experiment"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organizationIdentifier}/members" : {
-      "get" : {
-        "operationId" : "listOrganizationMembers",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/OrganizationMemberDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "addOrganizationMember",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "member",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/NewOrganizationMemberDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationMemberDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/verifyUpload" : {
-      "get" : {
-        "operationId" : "verifyUploadData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "path",
-          "required" : true,
-          "in" : "query",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/UploadVerification"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations/{organizationName}/projects/{projectName}/paths" : {
-      "get" : {
-        "operationId" : "getProjectPaths",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "projectName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectPaths"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/{organizationId}/cancelSubscription" : {
-      "post" : {
-        "operationId" : "cancelSubscription",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "subscriptionCancel",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/SubscriptionCancelInfoDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/chartSets" : {
-      "get" : {
-        "operationId" : "listProjectChartSets",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ChartSet"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createChartSet",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "chartSetToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChartSetParams"
-          }
-        }, {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChartSet"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/user" : {
-      "post" : {
-        "operationId" : "createChannel",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChannelParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChannelDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -5744,6 +784,27 @@
           "format" : "int32"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
@@ -5752,7 +813,27 @@
                 "$ref" : "#/definitions/UserListDTO"
               }
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/userProfile" : {
+      "patch" : {
+        "operationId" : "updateUserProfile",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "userProfileUpdate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/UserProfileUpdateDTO"
+          }
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -5762,17 +843,61 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/UserProfileDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getUserProfile",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/UserProfileDTO"
+            }
           }
         },
         "security" : [ {
@@ -5780,31 +905,101 @@
         } ]
       }
     },
-    "/api/backend/v1/organizations2/{organizationId}/avatar" : {
+    "/api/backend/v1/userProfile/avatar" : {
+      "get" : {
+        "operationId" : "getUserProfileAvatar",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
       "put" : {
-        "operationId" : "updateOrganizationAvatar",
+        "operationId" : "updateUserProfileAvatar",
         "summary" : "",
         "consumes" : [ "multipart/form-data" ],
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "organizationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
           "name" : "avatarFile",
           "required" : true,
           "in" : "formData",
           "type" : "file"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/LinkDTO"
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/userProfile/links" : {
+      "delete" : {
+        "operationId" : "deleteUserProfileLink",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "link",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/LinkDTO"
+          }
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -5814,17 +1009,62 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "post" : {
+        "operationId" : "addUserProfileLink",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "link",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/UserProfileLinkDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -5832,27 +1072,189 @@
         } ]
       }
     },
-    "/api/backend/v1/organizations2/{organizationIdentifier}/limits" : {
-      "get" : {
-        "operationId" : "getOrganizationLimits",
+    "/api/backend/v1/userProfile/password" : {
+      "put" : {
+        "operationId" : "changePassword",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "organizationIdentifier",
+          "name" : "passwordToUpdate",
           "required" : true,
-          "in" : "path",
-          "type" : "string"
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/PasswordChangeDTO"
+          }
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/PasswordChangeDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/channels/user" : {
+      "post" : {
+        "operationId" : "createChannel",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "channelToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ChannelParams"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ChannelDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/channels/values" : {
+      "post" : {
+        "operationId" : "postChannelValues",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "channelsValues",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/InputChannelValues"
+            }
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "type" : "array",
               "items" : {
-                "$ref" : "#/definitions/OrganizationLimitsDTO"
+                "$ref" : "#/definitions/BatchChannelValueErrorDTO"
               }
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/channels/{channelId}/csv" : {
+      "get" : {
+        "operationId" : "getChannelValuesCSV",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : false,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "channelId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "gzipped",
+          "required" : false,
+          "in" : "query",
+          "type" : "boolean"
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -5862,17 +1264,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -5880,7 +1285,298 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/abort" : {
+    "/api/leaderboard/v1/channels/{channelId}/values" : {
+      "get" : {
+        "operationId" : "getChannelValues",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "channelId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "offset",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "limit",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int32"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LimitedChannelValuesDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/channels/{id}/values" : {
+      "delete" : {
+        "operationId" : "resetChannel",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments" : {
+      "patch" : {
+        "operationId" : "updateExperiment",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "editExperimentParams",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/EditExperimentParams"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Experiment"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "post" : {
+        "operationId" : "createExperiment",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentCreationParams",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ExperimentCreationParams"
+          }
+        }, {
+          "name" : "X-Neptune-CliVersion",
+          "required" : false,
+          "in" : "header",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Experiment"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getExperiment",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Experiment"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments-attributes-names" : {
+      "get" : {
+        "operationId" : "getExperimentsAttributesNames",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ExperimentsAttributesNamesDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments/abort" : {
       "post" : {
         "operationId" : "abortExperiments",
         "summary" : "",
@@ -5903,6 +1599,27 @@
           "type" : "boolean"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
@@ -5911,7 +1628,33 @@
                 "$ref" : "#/definitions/BatchExperimentUpdateResult"
               }
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments/markCompleted" : {
+      "post" : {
+        "operationId" : "markExperimentCompleted",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "completedExperimentParams",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/CompletedExperimentParams"
+          }
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -5921,17 +1664,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -5939,25 +1685,19 @@
         } ]
       }
     },
-    "/api/backend/v1/storage2/downloadRequests/{id}" : {
-      "get" : {
-        "operationId" : "getDownloadPrepareRequest",
+    "/api/leaderboard/v1/experiments/ping" : {
+      "post" : {
+        "operationId" : "pingExperiment",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "id",
+          "name" : "experimentId",
           "required" : true,
-          "in" : "path",
+          "in" : "query",
           "type" : "string",
           "format" : "uuid"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/DownloadPrepareRequestDTO"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -5967,17 +1707,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -5985,16 +1728,18 @@
         } ]
       }
     },
-    "/api/backend/v1/userProfile/avatar" : {
+    "/api/leaderboard/v1/experiments/tags" : {
       "get" : {
-        "operationId" : "getUserProfileAvatar",
+        "operationId" : "tagsGet",
         "summary" : "",
         "deprecated" : false,
-        "parameters" : [ ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6004,17 +1749,26 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
           }
         },
         "security" : [ {
@@ -6022,23 +1776,18 @@
         } ]
       },
       "put" : {
-        "operationId" : "updateUserProfileAvatar",
+        "operationId" : "updateTags",
         "summary" : "",
-        "consumes" : [ "multipart/form-data" ],
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "avatarFile",
+          "name" : "updateTagsParams",
           "required" : true,
-          "in" : "formData",
-          "type" : "file"
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/UpdateTagsParams"
+          }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/LinkDTO"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6048,17 +1797,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6066,9 +1818,367 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/actions/{actionId}/invocations/{actionInvocationId}/markCompleted" : {
+    "/api/leaderboard/v1/experiments/trash" : {
       "post" : {
-        "operationId" : "markActionInvocationCompleted",
+        "operationId" : "trashExperiments",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentIds",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/BatchExperimentUpdateResult"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments/trash/empty" : {
+      "post" : {
+        "operationId" : "emptyExperimentsTrash",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentIds",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/BatchExperimentUpdateResult"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/experiments/trash/restore" : {
+      "post" : {
+        "operationId" : "restoreExperiments",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentIds",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "format" : "uuid"
+            }
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/BatchExperimentUpdateResult"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/deleteOutput" : {
+      "delete" : {
+        "operationId" : "deleteExperimentOutput",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "path",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/downloadRequest" : {
+      "get" : {
+        "operationId" : "getDownloadPrepareRequest",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "id",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/DownloadPrepareRequestDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/download" : {
+      "get" : {
+        "operationId" : "downloadData",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "path",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/downloadRequest" : {
+      "post" : {
+        "operationId" : "prepareForDownload",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentIdentity",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        }, {
+          "name" : "path",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/DownloadPrepareRequestDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadOutput/{experimentId}" : {
+      "post" : {
+        "operationId" : "uploadExperimentOutput",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
@@ -6077,30 +2187,8 @@
           "in" : "path",
           "type" : "string",
           "format" : "uuid"
-        }, {
-          "name" : "actionId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "actionInvocationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "completedActionParams",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/CompletedActionParams"
-          }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6110,17 +2198,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6128,24 +2219,19 @@
         } ]
       }
     },
-    "/api/backend/v1/storage/downloadPaymentInfo" : {
-      "get" : {
-        "operationId" : "getDownloadPaymentInfo",
+    "/api/leaderboard/v1/storage/legacy/uploadOutputAsTarStream/{experimentId}" : {
+      "post" : {
+        "operationId" : "uploadExperimentOutputAsTarstream",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "pathParam",
+          "name" : "experimentId",
           "required" : true,
-          "in" : "query",
-          "type" : "string"
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/DownloadPaymentInfo"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6155,17 +2241,1522 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadSource/{experimentId}" : {
+      "post" : {
+        "operationId" : "uploadExperimentSource",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadSourceAsTarStream/{experimentId}" : {
+      "post" : {
+        "operationId" : "uploadExperimentSourceAsTarstream",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations" : {
+      "get" : {
+        "operationId" : "listInvitations",
+        "summary" : "",
+        "description" : "Invitations are sorted from most to least recent.",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/InvitationListDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/organization" : {
+      "post" : {
+        "operationId" : "createOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "newOrganizationInvitation",
+          "description" : "addToAllProjects flag is ignored when roleGrant value is admin",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/NewOrganizationInvitationDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/organization/resend" : {
+      "post" : {
+        "operationId" : "resendOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "resendOrganizationInvitation",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ResendOrganizationInvitationDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/organization/{invitationId}" : {
+      "delete" : {
+        "operationId" : "revokeOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "put" : {
+        "operationId" : "updateOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "update",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/OrganizationInvitationUpdateDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/organization/{invitationId}/accept" : {
+      "post" : {
+        "operationId" : "acceptOrganizationInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/project" : {
+      "post" : {
+        "operationId" : "createProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "newProjectInvitation",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/NewProjectInvitationDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ProjectInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/project/resend" : {
+      "post" : {
+        "operationId" : "resendProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "resendProjectInvitation",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ResendProjectInvitationDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/project/{invitationId}" : {
+      "delete" : {
+        "operationId" : "revokeProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ProjectInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "put" : {
+        "operationId" : "updateProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "update",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ProjectInvitationUpdateDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ProjectInvitationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/invitations/project/{invitationId}/accept" : {
+      "post" : {
+        "operationId" : "acceptProjectInvitation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "invitationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/users" : {
+      "get" : {
+        "operationId" : "listUsers",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "username",
+          "required" : true,
+          "in" : "query",
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/PublicUserProfileDTO"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/users/{username}/avatar" : {
+      "get" : {
+        "operationId" : "getUserAvatar",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "username",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/user/pricingStatus" : {
+      "get" : {
+        "operationId" : "userPricingStatus",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/UserPricingStatusDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}" : {
+      "get" : {
+        "operationId" : "getCustomer",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/CustomerDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/creditCard" : {
+      "post" : {
+        "operationId" : "createCardUpdateSession",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "createSessionParams",
+          "description" : "Stripe Checkout Session details",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/CreateSessionParamsDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/SessionDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getCreditCard",
+        "summary" : "",
+        "description" : "Returns a Stripe Source object",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/downgrade" : {
+      "delete" : {
+        "operationId" : "downgradeTeamOrganization",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/invoices/past" : {
+      "get" : {
+        "operationId" : "getPastInvoices",
+        "summary" : "",
+        "description" : "Pass-through to Stripe /v1/invoices",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/invoices/upcoming" : {
+      "get" : {
+        "operationId" : "getUpcomingInvoice",
+        "summary" : "",
+        "description" : "Pass-through to Stripe /v1/invoices/upcoming",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "string"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/pricingPlan" : {
+      "get" : {
+        "operationId" : "getPricingPlan",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationPricingPlanDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationIdentifier}/session" : {
+      "post" : {
+        "operationId" : "createCheckoutSession",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "createSessionParams",
+          "description" : "Stripe Checkout Session details",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/CreateSessionParamsDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/SessionDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/payments/{organizationName}/synchronizeSubscription" : {
+      "put" : {
+        "operationId" : "synchronizeSubscription",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/achievements" : {
+      "get" : {
+        "operationId" : "getAchievements",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/AchievementsDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2" : {
+      "post" : {
+        "operationId" : "createOrganization",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/OrganizationCreationParamsDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "filterOrganizations",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "ids",
+          "required" : true,
+          "in" : "query",
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/OrganizationDTO"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationIdentifier}/limits" : {
+      "get" : {
+        "operationId" : "getOrganizationLimits",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationLimitsDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationIdentifier}/members" : {
+      "post" : {
+        "operationId" : "addOrganizationMember",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "member",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/NewOrganizationMemberDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationMemberDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "listOrganizationMembers",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/OrganizationMemberDTO"
+              }
+            }
           }
         },
         "security" : [ {
@@ -6190,9 +3781,6 @@
           "type" : "string"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6202,17 +3790,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6242,12 +3833,6 @@
           }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationMemberDTO"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6257,17 +3842,23 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationMemberDTO"
+            }
           }
         },
         "security" : [ {
@@ -6275,19 +3866,19 @@
         } ]
       }
     },
-    "/api/backend/v1/authorization/authorize" : {
-      "get" : {
-        "operationId" : "authorize",
+    "/api/backend/v1/organizations2/{organizationId}" : {
+      "delete" : {
+        "operationId" : "deleteOrganization",
         "summary" : "",
         "deprecated" : false,
-        "parameters" : [ ],
+        "parameters" : [ {
+          "name" : "organizationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/AuthorizedUserDTO"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6297,17 +3888,592 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "put" : {
+        "operationId" : "updateOrganization",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "organizationToUpdate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/OrganizationUpdateDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationId}/avatar" : {
+      "put" : {
+        "operationId" : "updateOrganizationAvatar",
+        "summary" : "",
+        "consumes" : [ "multipart/form-data" ],
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "avatarFile",
+          "required" : true,
+          "in" : "formData",
+          "type" : "file"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LinkDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationId}/cancelSubscription" : {
+      "post" : {
+        "operationId" : "cancelSubscription",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "subscriptionCancel",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/SubscriptionCancelInfoDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationName}/available" : {
+      "get" : {
+        "operationId" : "isOrganizationNameAvailable",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationNameAvailableDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organizationName}/avatar" : {
+      "get" : {
+        "operationId" : "getOrganizationAvatar",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations2/{organization}" : {
+      "get" : {
+        "operationId" : "getOrganization",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organization",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/OrganizationDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/clients/config" : {
+      "get" : {
+        "operationId" : "getClientConfig",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "X-Neptune-Api-Token",
+          "required" : true,
+          "in" : "header",
+          "type" : "string"
+        }, {
+          "name" : "alpha",
+          "required" : false,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ClientConfig"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/clients/sso" : {
+      "get" : {
+        "operationId" : "getSsoConfig",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "workspaceName",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/WorkspaceConfig"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/myOrganizations" : {
+      "get" : {
+        "operationId" : "listOrganizations",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/OrganizationWithRoleDTO"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/channels/lastValues" : {
+      "get" : {
+        "operationId" : "getChannelsLastValues",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/ChannelWithValueDTO"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/channels/system" : {
+      "post" : {
+        "operationId" : "createSystemChannel",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "channelToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ChannelParams"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ChannelDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getSystemChannels",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/ChannelDTO"
+              }
+            }
           }
         },
         "security" : [ {
@@ -6317,7 +4483,7 @@
     },
     "/api/backend/v1/channels/{channelId}/csv" : {
       "get" : {
-        "operationId" : "getChannelValuesCSV",
+        "operationId" : "deprecatedGetChannelValuesCSV",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
@@ -6339,9 +4505,6 @@
           "type" : "boolean"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6351,17 +4514,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6369,22 +4535,687 @@
         } ]
       }
     },
-    "/api/backend/v1/notebooks/{notebookId}" : {
-      "delete" : {
-        "operationId" : "deleteNotebook",
+    "/api/backend/v1/channels/{channelId}/values" : {
+      "get" : {
+        "operationId" : "deprecatedGetChannelValues",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "notebookId",
+          "name" : "channelId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "offset",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "limit",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int32"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LimitedChannelValuesDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/login/actions" : {
+      "get" : {
+        "operationId" : "getLoginActions",
+        "summary" : "",
+        "description" : "Returns a list of actions that backend requires the user to complete before he can start working with Neptune",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "409" : {
+            "description" : "Conflict"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LoginActionsListDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/login/survey" : {
+      "post" : {
+        "operationId" : "sendRegistrationSurvey",
+        "summary" : "",
+        "description" : "Processes the survey. Sending {} means that user declined survey and action is removed",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "survey",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/RegistrationSurveyDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/login/username" : {
+      "post" : {
+        "operationId" : "setUsername",
+        "summary" : "",
+        "description" : "\nSets the username as per param.\nCan be called once, subsequent calls will result in 403 error.\nSetting to an invalid username will result in 400 error.\nSetting to an unavailable username will result in 409 error.\n",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "username",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/login/username/validate" : {
+      "get" : {
+        "operationId" : "validateUsername",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "username",
+          "required" : true,
+          "in" : "query",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/UsernameValidationStatusDTO"
+            }
+          }
+        }
+      }
+    },
+    "/api/backend/v1/authorization/api-token" : {
+      "delete" : {
+        "operationId" : "revokeApiToken",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getApiToken",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/NeptuneApiToken"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/authorization/authorize" : {
+      "get" : {
+        "operationId" : "authorize",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/AuthorizedUserDTO"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/authorization/oauth-token" : {
+      "get" : {
+        "operationId" : "exchangeApiToken",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "X-Neptune-Api-Token",
+          "required" : true,
+          "in" : "header",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/NeptuneOauthToken"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/reservations" : {
+      "post" : {
+        "operationId" : "createReservation",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "newReservation",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/NewReservationDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/reservations/{organizationName}/questionnaire" : {
+      "put" : {
+        "operationId" : "sendQuestionnaire",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "questionnaireAnswers",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/QuestionnaireDTO"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/healthz" : {
+      "get" : {
+        "operationId" : "healthz",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/ComponentStatus"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/status" : {
+      "get" : {
+        "operationId" : "statusGet",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Status"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/chartSets" : {
+      "post" : {
+        "operationId" : "createChartSet",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "chartSetToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ChartSetParams"
+          }
+        }, {
+          "name" : "projectId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ChartSet"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "listProjectChartSets",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "projectId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/ChartSet"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/chartSets/{chartSetId}" : {
+      "delete" : {
+        "operationId" : "deleteChartSet",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "chartSetId",
           "required" : true,
           "in" : "path",
           "type" : "string",
           "format" : "uuid"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6394,27 +5225,72 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
           "oauth2" : [ ]
         } ]
-      }
-    },
-    "/api/backend/v1/chartSets/{chartSetId}/charts/{chartId}" : {
+      },
       "get" : {
-        "operationId" : "getChart",
+        "operationId" : "getChartSet",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "chartSetId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ChartSet"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "put" : {
+        "operationId" : "updateChartSet",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
@@ -6424,18 +5300,14 @@
           "type" : "string",
           "format" : "uuid"
         }, {
-          "name" : "chartId",
+          "name" : "chartSetToUpdate",
           "required" : true,
-          "in" : "path",
-          "type" : "string"
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ChartSetParams"
+          }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Chart"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6445,17 +5317,124 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ChartSet"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/chartSets/{chartSetId}/charts" : {
+      "post" : {
+        "operationId" : "createChart",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "chartToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/ChartDefinition"
+          }
+        }, {
+          "name" : "chartSetId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Chart"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/chartSets/{chartSetId}/charts/{chartId}" : {
+      "delete" : {
+        "operationId" : "deleteChart",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "chartId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "chartSetId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6486,78 +5465,32 @@
           }
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/Chart"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "delete" : {
-        "operationId" : "deleteChart",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "chartId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "chartSetId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -6565,9 +5498,192 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/stdout" : {
+    "/api/backend/v1/config" : {
+      "get" : {
+        "operationId" : "globalConfiguration",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/GlobalConfiguration"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/configInfo" : {
+      "get" : {
+        "operationId" : "configInfoGet",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ConfigInfo"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/experiments/{experimentId}/charts" : {
+      "get" : {
+        "operationId" : "getExperimentCharts",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "chartSetId",
+          "required" : true,
+          "in" : "query",
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Charts"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/experiments/{experimentId}/system/metrics" : {
       "post" : {
-        "operationId" : "uploadExperimentStdout",
+        "operationId" : "createSystemMetric",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "metricToCreate",
+          "required" : true,
+          "in" : "body",
+          "schema" : {
+            "$ref" : "#/definitions/SystemMetricParams"
+          }
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/SystemMetric"
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      },
+      "get" : {
+        "operationId" : "getSystemMetrics",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
@@ -6578,9 +5694,6 @@
           "format" : "uuid"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6590,52 +5703,8 @@
           "404" : {
             "description" : "Not Found"
           },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
           "408" : {
             "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/organization" : {
-      "post" : {
-        "operationId" : "createOrganizationInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "newOrganizationInvitation",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/NewOrganizationInvitationDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/OrganizationInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
           },
           "403" : {
             "description" : "Forbidden"
@@ -6643,34 +5712,42 @@
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations2/user" : {
-      "get" : {
-        "operationId" : "listOrganizations",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "type" : "array",
               "items" : {
-                "$ref" : "#/definitions/OrganizationWithRoleDTO"
+                "$ref" : "#/definitions/SystemMetric"
               }
             }
-          },
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/experiments/{experimentId}/system/metrics/csv" : {
+      "get" : {
+        "operationId" : "getSystemMetricsCSV",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "gzipped",
+          "required" : false,
+          "in" : "query",
+          "type" : "boolean"
+        } ],
+        "responses" : {
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6680,17 +5757,20 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6698,33 +5778,29 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/trash/empty" : {
+    "/api/backend/v1/experiments/{experimentId}/system/metrics/values" : {
       "post" : {
-        "operationId" : "emptyExperimentsTrash",
+        "operationId" : "postSystemMetricValues",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "experimentIds",
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "metricValues",
           "required" : true,
           "in" : "body",
           "schema" : {
             "type" : "array",
             "items" : {
-              "type" : "string",
-              "format" : "uuid"
+              "$ref" : "#/definitions/SystemMetricValues"
             }
           }
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/BatchExperimentUpdateResult"
-              }
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6734,17 +5810,188 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/experiments/{experimentId}/system/metrics/{metricId}/values" : {
+      "get" : {
+        "operationId" : "getSystemMetricValues",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "experimentId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "metricId",
+          "required" : true,
+          "in" : "path",
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "startPoint",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "endPoint",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int64"
+        }, {
+          "name" : "itemCount",
+          "required" : false,
+          "in" : "query",
+          "type" : "integer",
+          "format" : "int32"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
           "408" : {
             "description" : "Request Timeout"
           },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/SystemMetricValues"
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations/{organizationName}/projects/{projectName}/avatar" : {
+      "get" : {
+        "operationId" : "getProjectAvatar",
+        "summary" : "",
+        "produces" : [ "image/png" ],
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "projectName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ ]
+        } ]
+      }
+    },
+    "/api/backend/v1/organizations/{organizationName}/projects/{projectName}/background" : {
+      "get" : {
+        "operationId" : "getProjectBackground",
+        "summary" : "",
+        "deprecated" : false,
+        "parameters" : [ {
+          "name" : "organizationName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        }, {
+          "name" : "projectName",
+          "required" : true,
+          "in" : "path",
+          "type" : "string"
+        } ],
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "No response"
           }
         },
         "security" : [ {
@@ -6771,32 +6018,32 @@
           "type" : "file"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/Link"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -6804,10 +6051,11 @@
         } ]
       }
     },
-    "/api/backend/v1/projects1/{projectId}/stars" : {
-      "delete" : {
-        "operationId" : "unstarProject",
+    "/api/backend/v1/projects1/{projectId}/background" : {
+      "put" : {
+        "operationId" : "updateProjectBackground",
         "summary" : "",
+        "consumes" : [ "multipart/form-data" ],
         "deprecated" : false,
         "parameters" : [ {
           "name" : "projectId",
@@ -6815,114 +6063,13 @@
           "in" : "path",
           "type" : "string",
           "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/StarCount"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "starProject",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/StarCount"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/clone" : {
-      "post" : {
-        "operationId" : "cloneExperiments",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentIds",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "uuid"
-            }
-          }
         }, {
-          "name" : "targetProjectId",
+          "name" : "backgroundFile",
           "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "string",
-            "format" : "uuid"
-          }
+          "in" : "formData",
+          "type" : "file"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -6932,17 +6079,23 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Link"
+            }
           }
         },
         "security" : [ {
@@ -6950,705 +6103,49 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/system/metrics" : {
+    "/api/backend/v1/storage/usage" : {
       "get" : {
-        "operationId" : "getSystemMetrics",
+        "operationId" : "storageUsage",
         "summary" : "",
         "deprecated" : false,
         "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/SystemMetric"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "createSystemMetric",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "metricToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/SystemMetricParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/SystemMetric"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/organizations/{organizationName}/projects/{projectName}/background" : {
-      "get" : {
-        "operationId" : "getProjectBackground",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        }, {
-          "name" : "projectName",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/abort" : {
-      "post" : {
-        "operationId" : "abortExperiment",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "markOnly",
+          "name" : "organizationIdentifier",
           "required" : false,
           "in" : "query",
-          "type" : "boolean"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Experiment"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/features/new" : {
-      "get" : {
-        "operationId" : "getNewFeatures",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/FeatureDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/healthz" : {
-      "get" : {
-        "operationId" : "healthz",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ComponentStatus"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/authorization/oauth-token" : {
-      "get" : {
-        "operationId" : "exchangeApiToken",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "X-Neptune-Api-Token",
-          "required" : true,
-          "in" : "header",
+          "type" : "string"
+        }, {
+          "name" : "projectIdentifier",
+          "required" : false,
+          "in" : "query",
           "type" : "string"
         } ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/NeptuneOauthToken"
+              "$ref" : "#/definitions/StorageUsage"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}" : {
-      "get" : {
-        "operationId" : "getExperiment",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Experiment"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "patch" : {
-        "operationId" : "updateExperiment",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "editExperimentParams",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/EditExperimentParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/Experiment"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/features" : {
-      "get" : {
-        "operationId" : "getFeatures",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/FeatureDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/system/channels" : {
-      "get" : {
-        "operationId" : "deprecatedGetSystemChannels",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ChannelDTO"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "post" : {
-        "operationId" : "deprecatedCreateSystemChannel",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "channelToCreate",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ChannelParams"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ChannelDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/invitations/project/{invitationId}" : {
-      "delete" : {
-        "operationId" : "revokeProjectInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "get" : {
-        "operationId" : "getProjectInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      },
-      "put" : {
-        "operationId" : "updateProjectInvitation",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "invitationId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "update",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "$ref" : "#/definitions/ProjectInvitationUpdateDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ProjectInvitationDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -7663,32 +6160,32 @@
         "deprecated" : false,
         "parameters" : [ ],
         "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "schema" : {
+              "$ref" : "#/definitions/Error"
+            }
+          },
+          "404" : {
+            "description" : "Not Found"
+          },
+          "408" : {
+            "description" : "Request Timeout"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "422" : {
+            "description" : "Unprocessable Entity"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
           "200" : {
             "description" : "OK",
             "schema" : {
               "$ref" : "#/definitions/Version"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -7696,216 +6193,13 @@
         } ]
       }
     },
-    "/api/backend/v1/experiments/{experimentId}/finalizeExperimentUpload" : {
-      "post" : {
-        "operationId" : "finalizeExperimentUpload",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "targetExperimentIds",
-          "required" : true,
-          "in" : "body",
-          "schema" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "uuid"
-            }
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/data/upload" : {
-      "post" : {
-        "operationId" : "uploadData",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "projectId",
-          "required" : true,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "name" : "uploadId",
-          "required" : false,
-          "in" : "query",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/{id}/values" : {
-      "delete" : {
-        "operationId" : "resetChannel",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "id",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "No response"
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/payments/{organizationIdentifier}/subscription/upgrade" : {
-      "post" : {
-        "operationId" : "upgradeSubscription",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "organizationIdentifier",
-          "required" : true,
-          "in" : "path",
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/SubscriptionDTO"
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/gitHistory" : {
+    "/version" : {
       "get" : {
-        "operationId" : "getGitHistory",
+        "operationId" : "versionGet",
         "summary" : "",
         "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
+        "parameters" : [ ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/ExperimentGitHistory"
-            }
-          },
           "400" : {
             "description" : "Bad Request",
             "schema" : {
@@ -7915,142 +6209,23 @@
           "404" : {
             "description" : "Not Found"
           },
+          "408" : {
+            "description" : "Request Timeout"
+          },
           "403" : {
             "description" : "Forbidden"
           },
           "422" : {
             "description" : "Unprocessable Entity"
           },
-          "408" : {
-            "description" : "Request Timeout"
-          },
           "401" : {
             "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/channels/view" : {
-      "get" : {
-        "operationId" : "getChannelsView",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experiment",
-          "required" : true,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
           },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "channelName",
-          "required" : true,
-          "in" : "query",
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          },
-          "collectionFormat" : "multi"
-        }, {
-          "name" : "startPoint",
-          "required" : false,
-          "in" : "query",
-          "type" : "number",
-          "format" : "double"
-        }, {
-          "name" : "endPoint",
-          "required" : false,
-          "in" : "query",
-          "type" : "number",
-          "format" : "double"
-        }, {
-          "name" : "itemCount",
-          "required" : false,
-          "in" : "query",
-          "type" : "integer",
-          "format" : "int32"
-        } ],
-        "responses" : {
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/ChannelSeriesListDTO"
+              "$ref" : "#/definitions/Version"
             }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          }
-        },
-        "security" : [ {
-          "oauth2" : [ ]
-        } ]
-      }
-    },
-    "/api/backend/v1/experiments/{experimentId}/actionInvocations" : {
-      "get" : {
-        "operationId" : "getActionInvocations",
-        "summary" : "",
-        "deprecated" : false,
-        "parameters" : [ {
-          "name" : "experimentId",
-          "required" : true,
-          "in" : "path",
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/ActionInvocation"
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "schema" : {
-              "$ref" : "#/definitions/Error"
-            }
-          },
-          "404" : {
-            "description" : "Not Found"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "422" : {
-            "description" : "Unprocessable Entity"
-          },
-          "408" : {
-            "description" : "Request Timeout"
-          },
-          "401" : {
-            "description" : "Unauthorized"
           }
         },
         "security" : [ {
@@ -8060,15 +6235,26 @@
     }
   },
   "definitions" : {
+    "LinkTypeDTO" : {
+      "type" : "string",
+      "enum" : [ "github", "twitter", "kaggle", "linkedin", "other" ]
+    },
+    "ParameterTypeEnum" : {
+      "type" : "string",
+      "enum" : [ "double", "string" ]
+    },
+    "OrganizationNameAvailableDTO" : {
+      "type" : "object",
+      "properties" : {
+        "available" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "available" ]
+    },
     "RegisteredMemberInfoDTO" : {
       "type" : "object",
       "properties" : {
-        "username" : {
-          "type" : "string"
-        },
-        "avatarUrl" : {
-          "type" : "string"
-        },
         "avatarSource" : {
           "$ref" : "#/definitions/AvatarSourceEnum"
         },
@@ -8077,53 +6263,15 @@
         },
         "firstName" : {
           "type" : "string"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "avatarUrl" : {
+          "type" : "string"
         }
       },
       "required" : [ "username", "firstName", "lastName", "avatarUrl", "avatarSource" ]
-    },
-    "ExperimentWithCommit" : {
-      "type" : "object",
-      "properties" : {
-        "dirty" : {
-          "type" : "boolean"
-        },
-        "authorEmail" : {
-          "type" : "string"
-        },
-        "experimentName" : {
-          "type" : "string"
-        },
-        "commitId" : {
-          "type" : "string"
-        },
-        "experimentId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "message" : {
-          "type" : "string"
-        },
-        "commitDate" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "authorName" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "commitId", "message", "authorName", "authorEmail", "commitDate", "experimentId", "experimentName", "dirty" ]
-    },
-    "ProjectPaths" : {
-      "type" : "object",
-      "properties" : {
-        "location" : {
-          "type" : "string"
-        },
-        "uploads" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "location", "uploads" ]
     },
     "ProjectMemberDTO" : {
       "type" : "object",
@@ -8131,54 +6279,29 @@
         "role" : {
           "$ref" : "#/definitions/ProjectRoleDTO"
         },
-        "editableRole" : {
-          "type" : "boolean"
-        },
-        "canLeaveProject" : {
-          "type" : "boolean"
-        },
         "registeredMemberInfo" : {
           "$ref" : "#/definitions/RegisteredMemberInfoDTO"
         },
         "invitationInfo" : {
           "$ref" : "#/definitions/ProjectInvitationDTO"
+        },
+        "editableRole" : {
+          "type" : "boolean"
+        },
+        "canLeaveProject" : {
+          "type" : "boolean"
         }
       },
       "required" : [ "role", "editableRole", "canLeaveProject" ]
     },
-    "Alias" : {
+    "UsernameValidationStatusDTO" : {
       "type" : "object",
       "properties" : {
-        "id" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "projectId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "channels" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
+        "status" : {
+          "$ref" : "#/definitions/UsernameValidationStatusEnumDTO"
         }
       },
-      "required" : [ "id", "projectId", "name", "channels" ]
-    },
-    "CompletedActionParams" : {
-      "type" : "object",
-      "properties" : {
-        "result" : {
-          "type" : "string"
-        },
-        "traceback" : {
-          "type" : "string"
-        }
-      }
+      "required" : [ "status" ]
     },
     "InputMetadata" : {
       "type" : "object",
@@ -8203,9 +6326,6 @@
     "EditExperimentParams" : {
       "type" : "object",
       "properties" : {
-        "codeAccess" : {
-          "$ref" : "#/definitions/ExperimentCodeAccess"
-        },
         "name" : {
           "type" : "string"
         },
@@ -8223,12 +6343,6 @@
           "items" : {
             "$ref" : "#/definitions/KeyValueProperty"
           }
-        },
-        "actions" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Action"
-          }
         }
       }
     },
@@ -8243,40 +6357,6 @@
         }
       },
       "required" : [ "currentPassword", "newPassword" ]
-    },
-    "FeatureDTO" : {
-      "type" : "object",
-      "properties" : {
-        "headline" : {
-          "type" : "string"
-        },
-        "mediaType" : {
-          "$ref" : "#/definitions/FeatureMediaType"
-        },
-        "released" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "mediaUrl" : {
-          "type" : "string"
-        },
-        "id" : {
-          "type" : "string"
-        },
-        "isActive" : {
-          "type" : "boolean"
-        },
-        "isViewed" : {
-          "type" : "boolean"
-        },
-        "thumbnailUrl" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "id", "headline", "description", "mediaType", "mediaUrl", "thumbnailUrl", "released", "isActive", "isViewed" ]
     },
     "OrganizationMemberUpdateDTO" : {
       "type" : "object",
@@ -8312,6 +6392,149 @@
       },
       "required" : [ "experimentIds", "tagsToAdd", "tagsToDelete" ]
     },
+    "Experiment" : {
+      "type" : "object",
+      "properties" : {
+        "channels" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Channel"
+          }
+        },
+        "state" : {
+          "$ref" : "#/definitions/ExperimentState"
+        },
+        "timeOfCompletion" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "checkpointId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "paths" : {
+          "$ref" : "#/definitions/ExperimentPaths"
+        },
+        "responding" : {
+          "type" : "boolean"
+        },
+        "organizationId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "stateTransitions" : {
+          "$ref" : "#/definitions/StateTransitions"
+        },
+        "parameters" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Parameter"
+          }
+        },
+        "channelsLastValues" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ChannelWithValue"
+          }
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "notebookId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "projectName" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        },
+        "trashed" : {
+          "type" : "boolean"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "channelsSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "timeOfCreation" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "organizationName" : {
+          "type" : "string"
+        },
+        "isCodeAccessible" : {
+          "type" : "boolean"
+        },
+        "traceback" : {
+          "type" : "string"
+        },
+        "entrypoint" : {
+          "type" : "string"
+        },
+        "runningTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "inputs" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/InputMetadata"
+          }
+        },
+        "properties" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/KeyValueProperty"
+          }
+        },
+        "shortId" : {
+          "type" : "string"
+        },
+        "componentsVersions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ComponentVersion"
+          }
+        },
+        "owner" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "id", "shortId", "organizationId", "organizationName", "projectId", "projectName", "owner", "name", "description", "state", "stateTransitions", "responding", "trashed", "timeOfCreation", "runningTime", "tags", "properties", "channels", "channelsLastValues", "parameters", "storageSize", "channelsSize", "inputs", "componentsVersions", "paths" ]
+    },
+    "StorageUsage" : {
+      "type" : "object",
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "required" : [ "usage" ]
+    },
     "ProjectVisibilityDTO" : {
       "type" : "string",
       "enum" : [ "priv", "pub" ]
@@ -8338,170 +6561,14 @@
       },
       "required" : [ "id", "name", "parameterType", "value" ]
     },
-    "ZoneOffset" : {
+    "NeptuneApiToken" : {
       "type" : "object",
       "properties" : {
-        "totalSeconds" : {
-          "type" : "integer",
-          "format" : "int32"
+        "token" : {
+          "type" : "string"
         }
       },
-      "required" : [ "totalSeconds" ]
-    },
-    "Experiment" : {
-      "type" : "object",
-      "properties" : {
-        "channelsLastValues" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/ChannelWithValue"
-          }
-        },
-        "storageSize" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "channels" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Channel"
-          }
-        },
-        "codeAccess" : {
-          "$ref" : "#/definitions/ExperimentCodeAccess"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "notebookId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "projectName" : {
-          "type" : "string"
-        },
-        "backup" : {
-          "$ref" : "#/definitions/Backup"
-        },
-        "hostname" : {
-          "type" : "string"
-        },
-        "trashed" : {
-          "type" : "boolean"
-        },
-        "state" : {
-          "$ref" : "#/definitions/ExperimentState"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "timeOfCompletion" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "channelsSize" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "timeOfCreation" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "projectId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "organizationName" : {
-          "type" : "string"
-        },
-        "isCodeAccessible" : {
-          "type" : "boolean"
-        },
-        "runningTime" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "id" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "inputs" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/InputMetadata"
-          }
-        },
-        "properties" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/KeyValueProperty"
-          }
-        },
-        "shortId" : {
-          "type" : "string"
-        },
-        "timeOfEnteredRunningState" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "responding" : {
-          "type" : "boolean"
-        },
-        "actions" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Action"
-          }
-        },
-        "organizationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "owner" : {
-          "type" : "string"
-        },
-        "stateTransitions" : {
-          "$ref" : "#/definitions/StateTransitions"
-        },
-        "parameters" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Parameter"
-          }
-        }
-      },
-      "required" : [ "id", "shortId", "organizationId", "organizationName", "projectId", "projectName", "owner", "name", "description", "state", "stateTransitions", "responding", "trashed", "timeOfCreation", "runningTime", "tags", "properties", "channels", "channelsLastValues", "parameters", "actions", "storageSize", "channelsSize", "codeAccess", "backup", "inputs" ]
-    },
-    "StorageUsage" : {
-      "type" : "object",
-      "properties" : {
-        "usage" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      },
-      "required" : [ "usage" ]
-    },
-    "AliasParams" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "channels" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        }
-      },
-      "required" : [ "name", "channels" ]
+      "required" : [ "token" ]
     },
     "OrganizationUpdateDTO" : {
       "type" : "object",
@@ -8516,7 +6583,7 @@
     },
     "NameEnum" : {
       "type" : "string",
-      "enum" : [ "Client", "Backend" ]
+      "enum" : [ "Client" ]
     },
     "Series" : {
       "type" : "object",
@@ -8524,19 +6591,19 @@
         "seriesType" : {
           "$ref" : "#/definitions/SeriesType"
         },
-        "aliasId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "label" : {
-          "type" : "string"
-        },
         "channelName" : {
           "type" : "string"
         },
         "channelId" : {
           "type" : "string",
           "format" : "uuid"
+        },
+        "aliasId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "label" : {
+          "type" : "string"
         }
       },
       "required" : [ "label", "seriesType" ]
@@ -8561,15 +6628,6 @@
       },
       "required" : [ "id", "name", "channelType" ]
     },
-    "ActionInvocationParams" : {
-      "type" : "object",
-      "properties" : {
-        "argument" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "argument" ]
-    },
     "OrganizationInvitationUpdateDTO" : {
       "type" : "object",
       "properties" : {
@@ -8582,12 +6640,6 @@
     "UserListItemDTO" : {
       "type" : "object",
       "properties" : {
-        "username" : {
-          "type" : "string"
-        },
-        "avatarUrl" : {
-          "type" : "string"
-        },
         "avatarSource" : {
           "$ref" : "#/definitions/AvatarSourceEnum"
         },
@@ -8596,51 +6648,42 @@
         },
         "firstName" : {
           "type" : "string"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "avatarUrl" : {
+          "type" : "string"
         }
       },
       "required" : [ "username", "firstName", "lastName", "avatarUrl", "avatarSource" ]
     },
-    "ActionEvent" : {
-      "type" : "object",
-      "properties" : {
-        "eventType" : {
-          "$ref" : "#/definitions/ActionEventType"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "timestamp" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "actionId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "data" : {
-          "type" : "string"
-        },
-        "actionInvocationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        }
-      },
-      "required" : [ "actionInvocationId", "timestamp", "actionId", "name", "eventType", "data" ]
-    },
     "OrganizationMemberDTO" : {
       "type" : "object",
       "properties" : {
-        "registeredMemberInfo" : {
-          "$ref" : "#/definitions/RegisteredMemberInfoDTO"
-        },
         "role" : {
           "$ref" : "#/definitions/OrganizationRoleDTO"
+        },
+        "joinedAt" : {
+          "type" : "string",
+          "format" : "date-time"
         },
         "editableRole" : {
           "type" : "boolean"
         },
+        "registeredMemberInfo" : {
+          "$ref" : "#/definitions/RegisteredMemberInfoDTO"
+        },
         "invitationInfo" : {
           "$ref" : "#/definitions/OrganizationInvitationDTO"
+        },
+        "totalNumberOfProjects" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "numberOfProjects" : {
+          "type" : "integer",
+          "format" : "int32"
         }
       },
       "required" : [ "role", "editableRole" ]
@@ -8693,6 +6736,10 @@
       },
       "required" : [ "metricId", "seriesName", "values" ]
     },
+    "ProjectCodeAccessDTO" : {
+      "type" : "string",
+      "enum" : [ "default", "restricted" ]
+    },
     "SystemMetricResourceType" : {
       "type" : "string",
       "enum" : [ "CPU", "RAM", "GPU", "GPU_RAM", "OTHER" ]
@@ -8720,10 +6767,6 @@
       },
       "required" : [ "channelId", "channelName", "channelType", "x", "y" ]
     },
-    "ProjectCodeAccessDTO" : {
-      "type" : "string",
-      "enum" : [ "default", "restricted" ]
-    },
     "Error" : {
       "type" : "object",
       "properties" : {
@@ -8744,6 +6787,32 @@
       "type" : "string",
       "enum" : [ "viewer", "member", "manager" ]
     },
+    "ProjectMembersDTO" : {
+      "type" : "object",
+      "properties" : {
+        "projectName" : {
+          "type" : "string"
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "organizationName" : {
+          "type" : "string"
+        },
+        "members" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ProjectMemberDTO"
+          }
+        },
+        "organizationId" : {
+          "type" : "string",
+          "format" : "uuid"
+        }
+      },
+      "required" : [ "projectId", "organizationId", "projectName", "organizationName", "members" ]
+    },
     "Y" : {
       "type" : "object",
       "properties" : {
@@ -8761,19 +6830,6 @@
           "$ref" : "#/definitions/InputImageDTO"
         }
       }
-    },
-    "OffsetDateTime" : {
-      "type" : "object",
-      "properties" : {
-        "dateTime" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "offset" : {
-          "$ref" : "#/definitions/ZoneOffset"
-        }
-      },
-      "required" : [ "dateTime", "offset" ]
     },
     "Point" : {
       "type" : "object",
@@ -8813,15 +6869,6 @@
       },
       "required" : [ "state", "traceback" ]
     },
-    "LoginOrRegisterResponseDTO" : {
-      "type" : "object",
-      "properties" : {
-        "outcome" : {
-          "$ref" : "#/definitions/LoginOrRegisterOutcomeDTO"
-        }
-      },
-      "required" : [ "outcome" ]
-    },
     "SeriesDefinition" : {
       "type" : "object",
       "properties" : {
@@ -8844,19 +6891,10 @@
     "UserProfileDTO" : {
       "type" : "object",
       "properties" : {
-        "biography" : {
+        "usernameHash" : {
           "type" : "string"
-        },
-        "hasCreatedExperiments" : {
-          "type" : "boolean"
         },
         "email" : {
-          "type" : "string"
-        },
-        "username" : {
-          "type" : "string"
-        },
-        "avatarUrl" : {
           "type" : "string"
         },
         "hasLoggedToCli" : {
@@ -8865,20 +6903,36 @@
         "avatarSource" : {
           "$ref" : "#/definitions/AvatarSourceEnum"
         },
-        "lastName" : {
-          "type" : "string"
-        },
-        "links" : {
-          "$ref" : "#/definitions/UserProfileLinksDTO"
-        },
         "firstName" : {
           "type" : "string"
         },
         "shortInfo" : {
           "type" : "string"
+        },
+        "created" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "biography" : {
+          "type" : "string"
+        },
+        "hasCreatedExperiments" : {
+          "type" : "boolean"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "avatarUrl" : {
+          "type" : "string"
+        },
+        "lastName" : {
+          "type" : "string"
+        },
+        "links" : {
+          "$ref" : "#/definitions/UserProfileLinksDTO"
         }
       },
-      "required" : [ "username", "email", "firstName", "lastName", "shortInfo", "biography", "links", "avatarUrl", "avatarSource", "hasCreatedExperiments", "hasLoggedToCli" ]
+      "required" : [ "username", "usernameHash", "email", "firstName", "lastName", "shortInfo", "biography", "links", "avatarUrl", "avatarSource", "hasCreatedExperiments", "hasLoggedToCli", "created" ]
     },
     "ProjectKeyDTO" : {
       "type" : "object",
@@ -8889,111 +6943,6 @@
       },
       "required" : [ "proposal" ]
     },
-    "ExperimentEntryDTO" : {
-      "type" : "object",
-      "properties" : {
-        "channelsLastValues" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/ChannelWithValue"
-          }
-        },
-        "storageSize" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "notebookId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "projectName" : {
-          "type" : "string"
-        },
-        "hostname" : {
-          "type" : "string"
-        },
-        "trashed" : {
-          "type" : "boolean"
-        },
-        "state" : {
-          "$ref" : "#/definitions/ExperimentStateDTO"
-        },
-        "description" : {
-          "type" : "string"
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "timeOfCompletion" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "commitId" : {
-          "type" : "string"
-        },
-        "timeOfCreation" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "projectId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "organizationName" : {
-          "type" : "string"
-        },
-        "id" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "properties" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/KeyValueProperty"
-          }
-        },
-        "shortId" : {
-          "type" : "string"
-        },
-        "timeOfEnteredRunningState" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "responding" : {
-          "type" : "boolean"
-        },
-        "projectDeleted" : {
-          "type" : "boolean"
-        },
-        "organizationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "owner" : {
-          "type" : "string"
-        },
-        "parameters" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Parameter"
-          }
-        },
-        "billedOrganizationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "deleted" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "id", "shortId", "organizationId", "organizationName", "projectId", "projectName", "projectDeleted", "billedOrganizationId", "owner", "name", "description", "state", "responding", "trashed", "deleted", "timeOfCreation", "tags", "properties", "parameters", "channelsLastValues", "storageSize" ]
-    },
     "InvitationTypeEnumDTO" : {
       "type" : "string",
       "enum" : [ "user", "emailRecipient" ]
@@ -9003,17 +6952,6 @@
       "properties" : {
         "codeAccess" : {
           "$ref" : "#/definitions/ProjectCodeAccessDTO"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "lastActivity" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "starCount" : {
-          "type" : "integer",
-          "format" : "int32"
         },
         "avatarUrl" : {
           "type" : "string"
@@ -9027,35 +6965,16 @@
         "featured" : {
           "type" : "boolean"
         },
-        "timeOfCreation" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "userRoleInOrganization" : {
-          "$ref" : "#/definitions/OrganizationRoleDTO"
-        },
         "organizationName" : {
           "type" : "string"
         },
-        "avatarSource" : {
-          "$ref" : "#/definitions/AvatarSourceEnum"
-        },
-        "leaderboardEntryCount" : {
+        "version" : {
           "type" : "integer",
           "format" : "int32"
-        },
-        "starredByMe" : {
-          "type" : "boolean"
         },
         "id" : {
           "type" : "string",
           "format" : "uuid"
-        },
-        "userRoleInProject" : {
-          "$ref" : "#/definitions/ProjectRoleDTO"
-        },
-        "backgroundUrl" : {
-          "type" : "string"
         },
         "projectKey" : {
           "type" : "string"
@@ -9073,9 +6992,36 @@
         },
         "displayClass" : {
           "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "lastActivity" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "timeOfCreation" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "userRoleInOrganization" : {
+          "$ref" : "#/definitions/OrganizationRoleDTO"
+        },
+        "avatarSource" : {
+          "$ref" : "#/definitions/AvatarSourceEnum"
+        },
+        "leaderboardEntryCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "userRoleInProject" : {
+          "$ref" : "#/definitions/ProjectRoleDTO"
+        },
+        "backgroundUrl" : {
+          "type" : "string"
         }
       },
-      "required" : [ "id", "organizationId", "projectKey", "name", "visibility", "timeOfCreation", "leaderboardEntryCount", "starCount", "userCount", "lastActivity", "organizationName", "organizationType", "featured", "codeAccess", "starredByMe", "userRoleInProject", "avatarUrl", "avatarSource" ]
+      "required" : [ "id", "organizationId", "projectKey", "name", "visibility", "timeOfCreation", "leaderboardEntryCount", "userCount", "lastActivity", "organizationName", "organizationType", "featured", "codeAccess", "userRoleInProject", "avatarUrl", "avatarSource", "version" ]
     },
     "OrganizationRoleDTO" : {
       "type" : "string",
@@ -9093,15 +7039,22 @@
         "name" : {
           "type" : "string"
         },
+        "min" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "max" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "unit" : {
+          "type" : "string"
+        },
         "description" : {
           "type" : "string"
         },
         "resourceType" : {
           "$ref" : "#/definitions/SystemMetricResourceType"
-        },
-        "min" : {
-          "type" : "number",
-          "format" : "double"
         },
         "experimentId" : {
           "type" : "string",
@@ -9110,36 +7063,21 @@
         "id" : {
           "type" : "string",
           "format" : "uuid"
-        },
-        "max" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "unit" : {
-          "type" : "string"
         }
       },
       "required" : [ "name", "description", "resourceType", "series", "id", "experimentId" ]
     },
-    "ExperimentsList" : {
+    "WorkspaceConfig" : {
       "type" : "object",
       "properties" : {
-        "entries" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Experiment"
-          }
+        "realm" : {
+          "type" : "string"
         },
-        "matchingCount" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
-        "totalCount" : {
-          "type" : "integer",
-          "format" : "int32"
+        "idpHint" : {
+          "type" : "string"
         }
       },
-      "required" : [ "entries", "matchingCount", "totalCount" ]
+      "required" : [ "realm", "idpHint" ]
     },
     "UUID" : {
       "type" : "object",
@@ -9182,25 +7120,6 @@
       },
       "required" : [ "version" ]
     },
-    "SubscriptionTierDTO" : {
-      "type" : "object",
-      "description" : "amountInCents (USD) is the monthly subscription fee for this tier",
-      "properties" : {
-        "freeProjectsQuantity" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "paidProjectsQuantity" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "amountInCents" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      },
-      "required" : [ "freeProjectsQuantity", "paidProjectsQuantity", "amountInCents" ]
-    },
     "OrganizationInvitationDTO" : {
       "type" : "object",
       "properties" : {
@@ -9223,11 +7142,15 @@
         "status" : {
           "$ref" : "#/definitions/InvitationStatusEnumDTO"
         },
+        "createdAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
         "invitationType" : {
           "$ref" : "#/definitions/InvitationTypeEnumDTO"
         }
       },
-      "required" : [ "id", "organizationName", "invitedBy", "invitee", "invitationType", "roleGrant", "status" ]
+      "required" : [ "organizationName", "invitedBy", "invitee", "invitationType", "roleGrant", "status", "createdAt" ]
     },
     "ChannelTypeEnum" : {
       "type" : "string",
@@ -9256,9 +7179,17 @@
       },
       "required" : [ "channelId", "channelName", "channelType", "x", "y" ]
     },
-    "ExperimentCodeAccess" : {
-      "type" : "string",
-      "enum" : [ "projectDefault", "open" ]
+    "ResendProjectInvitationDTO" : {
+      "type" : "object",
+      "properties" : {
+        "projectIdentifier" : {
+          "type" : "string"
+        },
+        "inviteeEmail" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "projectIdentifier", "inviteeEmail" ]
     },
     "ChartDefinition" : {
       "type" : "object",
@@ -9275,14 +7206,9 @@
       },
       "required" : [ "name", "series" ]
     },
-    "ExperimentGitHistory" : {
-      "type" : "object",
-      "properties" : {
-        "experiment" : {
-          "$ref" : "#/definitions/ExperimentWithCommit"
-        }
-      },
-      "required" : [ "experiment" ]
+    "UsernameValidationStatusEnumDTO" : {
+      "type" : "string",
+      "enum" : [ "available", "invalid", "unavailable" ]
     },
     "ProjectInvitationDTO" : {
       "type" : "object",
@@ -9309,34 +7235,15 @@
         "status" : {
           "$ref" : "#/definitions/InvitationStatusEnumDTO"
         },
+        "createdAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
         "invitationType" : {
           "$ref" : "#/definitions/InvitationTypeEnumDTO"
         }
       },
-      "required" : [ "id", "organizationName", "projectName", "invitedBy", "invitee", "invitationType", "roleGrant", "status" ]
-    },
-    "FileEntry" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "size" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "permissions" : {
-          "type" : "string"
-        },
-        "fileType" : {
-          "type" : "string"
-        },
-        "mtime" : {
-          "type" : "string",
-          "format" : "date-time"
-        }
-      },
-      "required" : [ "name", "permissions", "size", "mtime" ]
+      "required" : [ "organizationName", "projectName", "invitedBy", "invitee", "invitationType", "roleGrant", "status", "createdAt" ]
     },
     "OrganizationWithRoleDTO" : {
       "type" : "object",
@@ -9366,45 +7273,12 @@
           "type" : "string",
           "format" : "uuid"
         },
-        "paid" : {
-          "type" : "boolean"
-        },
         "created" : {
           "type" : "string",
           "format" : "date-time"
         }
       },
-      "required" : [ "name", "id", "paid", "created", "paymentStatus", "avatarUrl", "avatarSource", "organizationType" ]
-    },
-    "ExperimentStateDTO" : {
-      "type" : "string",
-      "enum" : [ "running", "succeeded", "failed", "aborted" ]
-    },
-    "NumericChannelValueDTO" : {
-      "type" : "object",
-      "properties" : {
-        "x" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "timestamp" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "y" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "maxy" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "miny" : {
-          "type" : "number",
-          "format" : "double"
-        }
-      },
-      "required" : [ "x", "y", "miny", "maxy", "timestamp" ]
+      "required" : [ "name", "id", "created", "paymentStatus", "avatarUrl", "avatarSource", "organizationType" ]
     },
     "DiscountCodeDTO" : {
       "type" : "object",
@@ -9415,47 +7289,17 @@
       },
       "required" : [ "code" ]
     },
-    "ChannelSeriesListDTO" : {
-      "type" : "object",
-      "properties" : {
-        "elements" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/ChannelSeriesDTO"
-          }
-        }
-      },
-      "required" : [ "elements" ]
-    },
     "ExperimentPaths" : {
       "type" : "object",
       "properties" : {
-        "source" : {
-          "type" : "string"
-        },
-        "backup" : {
-          "type" : "string"
-        },
-        "location" : {
-          "type" : "string"
-        },
-        "entryPoint" : {
-          "type" : "string"
-        },
-        "stdout" : {
-          "type" : "string"
-        },
-        "stderr" : {
-          "type" : "string"
-        },
-        "configPath" : {
-          "type" : "string"
-        },
         "output" : {
+          "type" : "string"
+        },
+        "source" : {
           "type" : "string"
         }
       },
-      "required" : [ "location", "output", "backup", "stdout", "stderr", "source", "entryPoint" ]
+      "required" : [ "output", "source" ]
     },
     "ChannelDTO" : {
       "type" : "object",
@@ -9486,43 +7330,43 @@
       },
       "required" : [ "username" ]
     },
-    "LocalDate" : {
+    "GlobalConfiguration" : {
       "type" : "object",
       "properties" : {
-        "year" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
-        "month" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
-        "day" : {
-          "type" : "integer",
-          "format" : "int32"
+        "licenseExpiration" : {
+          "type" : "string",
+          "format" : "date-time"
         }
       },
-      "required" : [ "year", "month", "day" ]
+      "required" : [ "licenseExpiration" ]
     },
-    "SourceInfo" : {
+    "ClientConfig" : {
       "type" : "object",
       "properties" : {
-        "executable" : {
+        "apiUrl" : {
           "type" : "string"
         },
-        "path" : {
+        "applicationUrl" : {
           "type" : "string"
+        },
+        "pyLibVersions" : {
+          "$ref" : "#/definitions/ClientVersionsConfigDTO"
         }
       },
-      "required" : [ "executable", "path" ]
-    },
-    "LinkTypeDTO" : {
-      "type" : "string",
-      "enum" : [ "github", "twitter", "kaggle", "linkedin", "other" ]
+      "required" : [ "apiUrl", "applicationUrl", "pyLibVersions" ]
     },
     "GitInfoDTO" : {
       "type" : "object",
       "properties" : {
+        "currentBranch" : {
+          "type" : "string"
+        },
+        "remotes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
         "commit" : {
           "$ref" : "#/definitions/GitCommitDTO"
         },
@@ -9532,86 +7376,29 @@
       },
       "required" : [ "commit", "repositoryDirty" ]
     },
-    "SubscriptionDTO" : {
+    "CustomerDTO" : {
       "type" : "object",
       "properties" : {
-        "lowerTier" : {
-          "$ref" : "#/definitions/SubscriptionTierDTO"
+        "numberOfUsers" : {
+          "type" : "integer",
+          "format" : "int64"
         },
-        "currentTier" : {
-          "$ref" : "#/definitions/SubscriptionTierDTO"
+        "userPriceInCents" : {
+          "type" : "integer",
+          "format" : "int64"
         },
-        "higherTier" : {
-          "$ref" : "#/definitions/SubscriptionTierDTO"
+        "pricingPlan" : {
+          "$ref" : "#/definitions/PricingPlanDTO"
         },
         "discount" : {
           "$ref" : "#/definitions/DiscountDTO"
         }
       },
-      "required" : [ "currentTier", "higherTier" ]
-    },
-    "CustomerDTO" : {
-      "type" : "object",
-      "properties" : {
-        "numberOfProjects" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "subscription" : {
-          "$ref" : "#/definitions/SubscriptionDTO"
-        }
-      },
-      "required" : [ "numberOfProjects", "subscription" ]
+      "required" : [ "userPriceInCents", "pricingPlan" ]
     },
     "PricingPlanDTO" : {
-      "type" : "object",
-      "properties" : {
-        "privateProjectTransferQuota" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "initialBonus" : {
-          "type" : "number"
-        },
-        "name" : {
-          "type" : "string"
-        },
-        "freeStorage" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "organizationTransferQuota" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "userPrice" : {
-          "type" : "number"
-        },
-        "publicProjectTransferQuota" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "storagePrice" : {
-          "type" : "number"
-        },
-        "privateProjects" : {
-          "type" : "boolean"
-        },
-        "maxConcurrentExperimentsPerUser" : {
-          "type" : "integer",
-          "format" : "int32"
-        },
-        "id" : {
-          "type" : "string"
-        },
-        "available" : {
-          "type" : "boolean"
-        },
-        "transferPrice" : {
-          "type" : "number"
-        }
-      },
-      "required" : [ "id", "name", "storagePrice", "transferPrice", "organizationTransferQuota", "publicProjectTransferQuota", "privateProjectTransferQuota", "freeStorage", "userPrice", "initialBonus", "maxConcurrentExperimentsPerUser", "available", "privateProjects" ]
+      "type" : "string",
+      "enum" : [ "free", "academia", "paid", "enterprise", "trial" ]
     },
     "ChannelParams" : {
       "type" : "object",
@@ -9625,10 +7412,6 @@
       },
       "required" : [ "name", "channelType" ]
     },
-    "UserPaymentSource" : {
-      "type" : "string",
-      "enum" : [ "free", "quota", "creditCard" ]
-    },
     "File" : {
       "type" : "object",
       "properties" : {
@@ -9638,43 +7421,18 @@
       },
       "required" : [ "path" ]
     },
-    "LocalDateTime" : {
-      "type" : "object",
-      "properties" : {
-        "date" : {
-          "type" : "string",
-          "format" : "date"
-        },
-        "time" : {
-          "$ref" : "#/definitions/LocalTime"
-        }
-      },
-      "required" : [ "date", "time" ]
-    },
     "ExperimentCreationParams" : {
       "type" : "object",
       "properties" : {
         "monitored" : {
           "type" : "boolean"
         },
-        "name" : {
-          "type" : "string"
-        },
-        "notebookId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
         "hostname" : {
           "type" : "string"
         },
-        "description" : {
-          "type" : "string"
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
+        "checkpointId" : {
+          "type" : "string",
+          "format" : "uuid"
         },
         "projectId" : {
           "type" : "string",
@@ -9682,12 +7440,6 @@
         },
         "gitInfo" : {
           "$ref" : "#/definitions/GitInfoDTO"
-        },
-        "abortable" : {
-          "type" : "boolean"
-        },
-        "entrypoint" : {
-          "type" : "string"
         },
         "properties" : {
           "type" : "array",
@@ -9709,25 +7461,40 @@
         },
         "enqueueCommand" : {
           "type" : "string"
-        }
-      },
-      "required" : [ "name", "tags", "parameters", "properties", "enqueueCommand", "entrypoint", "execArgsTemplate", "projectId" ]
-    },
-    "UploadVerification" : {
-      "type" : "object",
-      "properties" : {
-        "checksums" : {
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "notebookId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "tags" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/FileChecksum"
+            "type" : "string"
           }
         },
-        "filelength" : {
-          "type" : "integer",
-          "format" : "int64"
+        "abortable" : {
+          "type" : "boolean"
+        },
+        "entrypoint" : {
+          "type" : "string"
         }
       },
-      "required" : [ "checksums", "filelength" ]
+      "required" : [ "name", "tags", "parameters", "properties", "enqueueCommand", "execArgsTemplate", "projectId" ]
+    },
+    "RegistrationSurveyDTO" : {
+      "type" : "object",
+      "properties" : {
+        "survey" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "survey" ]
     },
     "BatchExperimentUpdateResult" : {
       "type" : "object",
@@ -9778,6 +7545,28 @@
       },
       "required" : [ "projectIdentifier", "invitee", "invitationType", "roleGrant" ]
     },
+    "KeyValueProperty" : {
+      "type" : "object",
+      "properties" : {
+        "key" : {
+          "type" : "string"
+        },
+        "value" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "key", "value" ]
+    },
+    "ConfigInfo" : {
+      "type" : "object",
+      "properties" : {
+        "maxFormContentSize" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      },
+      "required" : [ "maxFormContentSize" ]
+    },
     "InputChannelValues" : {
       "type" : "object",
       "properties" : {
@@ -9797,15 +7586,6 @@
     "ChartSet" : {
       "type" : "object",
       "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "charts" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/Chart"
-          }
-        },
         "isEditable" : {
           "type" : "boolean"
         },
@@ -9819,73 +7599,35 @@
         "id" : {
           "type" : "string",
           "format" : "uuid"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "charts" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Chart"
+          }
         }
       },
       "required" : [ "name", "id", "projectId" ]
     },
-    "KeyValueProperty" : {
-      "type" : "object",
-      "properties" : {
-        "key" : {
-          "type" : "string"
-        },
-        "value" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "key", "value" ]
-    },
-    "FileDetails" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "size" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "permissions" : {
-          "type" : "string"
-        },
-        "mtime" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "childrenCount" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      },
-      "required" : [ "name", "permissions", "size", "mtime", "childrenCount" ]
-    },
-    "FeatureMediaType" : {
+    "AchievementTypeDTO" : {
       "type" : "string",
-      "enum" : [ "image", "youtube" ]
+      "enum" : [ "artifactSent", "experimentCreated", "imageSent", "parameterSet", "sourceUploaded", "tagSet", "textSent" ]
     },
-    "ConfigInfo" : {
+    "CreateSessionParamsDTO" : {
       "type" : "object",
+      "description" : "Stripe Checkout Session details",
       "properties" : {
-        "maxFormContentSize" : {
-          "type" : "integer",
-          "format" : "int32"
+        "successUrl" : {
+          "type" : "string"
+        },
+        "failureUrl" : {
+          "type" : "string"
         }
       },
-      "required" : [ "maxFormContentSize" ]
-    },
-    "ParameterTypeEnum" : {
-      "type" : "string",
-      "enum" : [ "double", "string" ]
-    },
-    "OrganizationExternalActivityDTO" : {
-      "type" : "object",
-      "properties" : {
-        "externalOrganizationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        }
-      },
-      "required" : [ "externalOrganizationId" ]
+      "required" : [ "successUrl", "failureUrl" ]
     },
     "LinkDTO" : {
       "type" : "object",
@@ -9947,9 +7689,32 @@
       },
       "required" : [ "name", "status" ]
     },
+    "ClientVersionsConfigDTO" : {
+      "type" : "object",
+      "properties" : {
+        "minRecommendedVersion" : {
+          "type" : "string"
+        },
+        "minCompatibleVersion" : {
+          "type" : "string"
+        },
+        "maxCompatibleVersion" : {
+          "type" : "string"
+        }
+      }
+    },
     "InvitationStatusEnumDTO" : {
       "type" : "string",
       "enum" : [ "pending", "accepted", "rejected", "revoked" ]
+    },
+    "OrganizationPricingPlanDTO" : {
+      "type" : "object",
+      "properties" : {
+        "pricingPlan" : {
+          "$ref" : "#/definitions/PricingPlanDTO"
+        }
+      },
+      "required" : [ "pricingPlan" ]
     },
     "OrganizationDTO" : {
       "type" : "object",
@@ -9976,15 +7741,12 @@
           "type" : "string",
           "format" : "uuid"
         },
-        "paid" : {
-          "type" : "boolean"
-        },
         "created" : {
           "type" : "string",
           "format" : "date-time"
         }
       },
-      "required" : [ "id", "name", "paid", "created", "paymentStatus", "avatarUrl", "avatarSource", "organizationType" ]
+      "required" : [ "id", "name", "created", "paymentStatus", "avatarUrl", "avatarSource", "organizationType" ]
     },
     "OutputImageDTO" : {
       "type" : "object",
@@ -10007,6 +7769,24 @@
       "type" : "string",
       "enum" : [ "running", "succeeded", "failed", "aborted" ]
     },
+    "InvitationListDTO" : {
+      "type" : "object",
+      "properties" : {
+        "projectInvitations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ProjectInvitationDTO"
+          }
+        },
+        "organizationInvitations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/OrganizationInvitationDTO"
+          }
+        }
+      },
+      "required" : [ "projectInvitations", "organizationInvitations" ]
+    },
     "BatchChannelValueErrorDTO" : {
       "type" : "object",
       "properties" : {
@@ -10026,7 +7806,19 @@
     },
     "ApiErrorTypeDTO" : {
       "type" : "string",
-      "enum" : [ "DUPLICATE_PARAMETER", "INVALID_NUMERIC_PARAMETER_VALUE", "INVALID_TAG", "LIMIT_OF_CHANNELS_IN_EXPERIMENT_REACHED", "LIMIT_OF_EXPERIMENTS_IN_PROJECT_REACHED", "LIMIT_OF_EXPERIMENTS_IN_GROUP_REACHED", "LIMIT_OF_PROJECTS_REACHED", "LIMIT_OF_RUNNING_EXPERIMENTS_PER_USER_REACHED", "LIMIT_OF_STORAGE_IN_PROJECT_REACHED", "LIMIT_OF_VALUES_IN_CHANNEL_REACHED", "LICENSE_EXPIRED" ]
+      "enum" : [ "WRONG_SSO_IDP", "LIMIT_OF_PROJECTS_REACHED", "LIMIT_OF_STORAGE_IN_PROJECT_REACHED", "LIMIT_OF_MEMBERS_IN_ORGANIZATION_REACHED", "LIMIT_OF_VALUES_IN_CHANNEL_REACHED" ]
+    },
+    "LoginActionsListDTO" : {
+      "type" : "object",
+      "properties" : {
+        "requiredActions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LoginActionDTO"
+          }
+        }
+      },
+      "required" : [ "requiredActions" ]
     },
     "ProjectListDTO" : {
       "type" : "object",
@@ -10051,6 +7843,10 @@
     "DiscountDTO" : {
       "type" : "object",
       "properties" : {
+        "amountOffPercentage" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
         "amountOffInCents" : {
           "type" : "integer",
           "format" : "int64"
@@ -10059,8 +7855,7 @@
           "type" : "string",
           "format" : "date-time"
         }
-      },
-      "required" : [ "amountOffInCents" ]
+      }
     },
     "StateTransitions" : {
       "type" : "object",
@@ -10087,10 +7882,6 @@
       "type" : "string",
       "enum" : [ "numeric", "text", "image" ]
     },
-    "LoginOrRegisterOutcomeDTO" : {
-      "type" : "string",
-      "enum" : [ "LOGGED_IN", "REGISTERED" ]
-    },
     "SystemMetricParams" : {
       "type" : "object",
       "properties" : {
@@ -10103,12 +7894,6 @@
         "name" : {
           "type" : "string"
         },
-        "description" : {
-          "type" : "string"
-        },
-        "resourceType" : {
-          "$ref" : "#/definitions/SystemMetricResourceType"
-        },
         "min" : {
           "type" : "number",
           "format" : "double"
@@ -10119,9 +7904,27 @@
         },
         "unit" : {
           "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "resourceType" : {
+          "$ref" : "#/definitions/SystemMetricResourceType"
         }
       },
       "required" : [ "name", "description", "resourceType", "series" ]
+    },
+    "UserPricingStatusDTO" : {
+      "type" : "object",
+      "properties" : {
+        "canCreateTeamFree" : {
+          "type" : "boolean"
+        },
+        "anyTeamFree" : {
+          "$ref" : "#/definitions/OrganizationWithRoleDTO"
+        }
+      },
+      "required" : [ "canCreateTeamFree" ]
     },
     "ProjectInvitationUpdateDTO" : {
       "type" : "object",
@@ -10131,45 +7934,6 @@
         }
       },
       "required" : [ "roleGrant" ]
-    },
-    "OrganizationAccountDTO" : {
-      "type" : "object",
-      "properties" : {
-        "pendingPayments" : {
-          "type" : "number"
-        },
-        "instanceDeletion" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "bonus" : {
-          "type" : "number"
-        },
-        "billingEmail" : {
-          "type" : "string"
-        },
-        "balance" : {
-          "type" : "number"
-        },
-        "customerId" : {
-          "type" : "string"
-        },
-        "id" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "seatsAvailable" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "pendingPaymentsFromPreviousMonths" : {
-          "type" : "number"
-        },
-        "pricingPlan" : {
-          "$ref" : "#/definitions/PricingPlanDTO"
-        }
-      },
-      "required" : [ "id", "pricingPlan", "bonus", "balance" ]
     },
     "UserProfileLinkDTO" : {
       "type" : "object",
@@ -10201,57 +7965,33 @@
       },
       "required" : [ "manualCharts", "defaultCharts" ]
     },
-    "ChannelSeriesDTO" : {
+    "SessionDTO" : {
       "type" : "object",
       "properties" : {
-        "experimentShortId" : {
+        "sessionId" : {
           "type" : "string"
-        },
-        "projectName" : {
-          "type" : "string"
-        },
-        "minY" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "channelName" : {
-          "type" : "string"
-        },
-        "projectId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "organizationName" : {
-          "type" : "string"
-        },
-        "experimentId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "maxY" : {
-          "type" : "number",
-          "format" : "double"
-        },
-        "values" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/NumericChannelValueDTO"
-          }
-        },
-        "organizationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "channelId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "level" : {
-          "type" : "integer",
-          "format" : "int32"
         }
       },
-      "required" : [ "organizationName", "organizationId", "projectName", "projectId", "experimentShortId", "experimentId", "channelId", "channelName", "level", "values", "minY", "maxY" ]
+      "required" : [ "sessionId" ]
+    },
+    "AvatarSourceEnum" : {
+      "type" : "string",
+      "enum" : [ "default", "thirdParty", "user", "inherited" ]
+    },
+    "OrganizationCreationParamsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "organizationType" : {
+          "$ref" : "#/definitions/OrganizationTypeDTO"
+        },
+        "discountCode" : {
+          "$ref" : "#/definitions/DiscountCodeDTO"
+        }
+      },
+      "required" : [ "name", "organizationType" ]
     },
     "UserProfileLinksDTO" : {
       "type" : "object",
@@ -10281,25 +8021,6 @@
       "type" : "string",
       "enum" : [ "line", "dot" ]
     },
-    "AvatarSourceEnum" : {
-      "type" : "string",
-      "enum" : [ "default", "thirdParty", "user", "inherited" ]
-    },
-    "OrganizationCreationParamsDTO" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "organizationType" : {
-          "$ref" : "#/definitions/OrganizationTypeDTO"
-        },
-        "discountCode" : {
-          "$ref" : "#/definitions/DiscountCodeDTO"
-        }
-      },
-      "required" : [ "name", "organizationType" ]
-    },
     "ComponentVersion" : {
       "type" : "object",
       "properties" : {
@@ -10312,15 +8033,17 @@
       },
       "required" : [ "name", "version" ]
     },
-    "StarCount" : {
+    "ResendOrganizationInvitationDTO" : {
       "type" : "object",
       "properties" : {
-        "starCount" : {
-          "type" : "integer",
-          "format" : "int32"
+        "organizationIdentifier" : {
+          "type" : "string"
+        },
+        "inviteeEmail" : {
+          "type" : "string"
         }
       },
-      "required" : [ "starCount" ]
+      "required" : [ "organizationIdentifier", "inviteeEmail" ]
     },
     "PublicUserProfileDTO" : {
       "type" : "object",
@@ -10331,26 +8054,26 @@
         "email" : {
           "type" : "string"
         },
-        "username" : {
-          "type" : "string"
-        },
-        "avatarUrl" : {
-          "type" : "string"
-        },
         "avatarSource" : {
           "$ref" : "#/definitions/AvatarSourceEnum"
-        },
-        "lastName" : {
-          "type" : "string"
-        },
-        "links" : {
-          "$ref" : "#/definitions/UserProfileLinksDTO"
         },
         "firstName" : {
           "type" : "string"
         },
         "shortInfo" : {
           "type" : "string"
+        },
+        "username" : {
+          "type" : "string"
+        },
+        "avatarUrl" : {
+          "type" : "string"
+        },
+        "lastName" : {
+          "type" : "string"
+        },
+        "links" : {
+          "$ref" : "#/definitions/UserProfileLinksDTO"
         }
       },
       "required" : [ "username", "shortInfo", "biography", "links", "avatarUrl", "avatarSource" ]
@@ -10362,85 +8085,43 @@
           "type" : "integer",
           "format" : "int64"
         },
-        "experimentCount" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
         "privateProjectMembers" : {
           "type" : "integer",
           "format" : "int64"
-        }
-      }
-    },
-    "Backup" : {
-      "type" : "object",
-      "properties" : {
-        "path" : {
-          "type" : "string"
         },
-        "size" : {
+        "membersLimit" : {
           "type" : "integer",
           "format" : "int64"
         },
-        "globs" : {
+        "isExpired" : {
+          "type" : "boolean"
+        },
+        "projectsLimit" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "expirationDate" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      },
+      "required" : [ "isExpired" ]
+    },
+    "LoginActionDTO" : {
+      "type" : "string",
+      "enum" : [ "SET_USERNAME", "SURVEY" ]
+    },
+    "AchievementsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "earned" : {
           "type" : "array",
           "items" : {
-            "type" : "string"
+            "$ref" : "#/definitions/AchievementTypeDTO"
           }
         }
       },
-      "required" : [ "path", "size", "globs" ]
-    },
-    "FileChecksum" : {
-      "type" : "object",
-      "properties" : {
-        "start" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "end" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "checksum" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "start", "end", "checksum" ]
-    },
-    "ActionInvocation" : {
-      "type" : "object",
-      "properties" : {
-        "actionInvocationState" : {
-          "$ref" : "#/definitions/ActionEventType"
-        },
-        "actionId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "finished" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "result" : {
-          "type" : "string"
-        },
-        "actionInvocationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "actionName" : {
-          "type" : "string"
-        },
-        "started" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "argument" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "actionName", "actionId", "actionInvocationId", "started", "argument", "actionInvocationState" ]
+      "required" : [ "earned" ]
     },
     "ProjectUpdateDTO" : {
       "type" : "object",
@@ -10465,6 +8146,12 @@
     "NewOrganizationInvitationDTO" : {
       "type" : "object",
       "properties" : {
+        "roleGrant" : {
+          "$ref" : "#/definitions/OrganizationRoleDTO"
+        },
+        "addToAllProjects" : {
+          "type" : "boolean"
+        },
         "organizationIdentifier" : {
           "type" : "string"
         },
@@ -10473,12 +8160,9 @@
         },
         "invitationType" : {
           "$ref" : "#/definitions/InvitationTypeEnumDTO"
-        },
-        "roleGrant" : {
-          "$ref" : "#/definitions/OrganizationRoleDTO"
         }
       },
-      "required" : [ "organizationIdentifier", "invitee", "invitationType", "roleGrant" ]
+      "required" : [ "organizationIdentifier", "invitee", "invitationType", "roleGrant", "addToAllProjects" ]
     },
     "UserListDTO" : {
       "type" : "object",
@@ -10500,39 +8184,41 @@
       },
       "required" : [ "entries", "matchingItemCount", "totalItemCount" ]
     },
-    "ActionEventType" : {
-      "type" : "string",
-      "enum" : [ "actionInvoked", "actionSucceeded", "actionFailed" ]
-    },
-    "ExecutionInfo" : {
+    "ExperimentsAttributesNamesDTO" : {
       "type" : "object",
       "properties" : {
-        "command" : {
-          "type" : "string"
-        },
-        "traceback" : {
-          "type" : "string"
-        },
-        "sourceInfo" : {
-          "$ref" : "#/definitions/SourceInfo"
-        },
-        "componentsVersions" : {
+        "textParametersNames" : {
           "type" : "array",
           "items" : {
-            "$ref" : "#/definitions/ComponentVersion"
+            "type" : "string"
           }
         },
-        "configPath" : {
-          "type" : "string"
+        "propertiesNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
-        "output" : {
-          "$ref" : "#/definitions/StorageLocation"
+        "numericChannelsNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
-        "execArgsTemplate" : {
-          "type" : "string"
+        "numericParametersNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "textChannelsNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         }
       },
-      "required" : [ "command", "execArgsTemplate", "componentsVersions", "output", "sourceInfo" ]
+      "required" : [ "numericParametersNames", "textParametersNames", "propertiesNames", "numericChannelsNames", "textChannelsNames" ]
     },
     "LimitedChannelValuesDTO" : {
       "type" : "object",
@@ -10565,38 +8251,6 @@
         }
       },
       "required" : [ "userId", "role" ]
-    },
-    "LocalTime" : {
-      "type" : "object",
-      "properties" : {
-        "hour" : {
-          "type" : "string",
-          "format" : "byte"
-        },
-        "minute" : {
-          "type" : "string",
-          "format" : "byte"
-        },
-        "second" : {
-          "type" : "string",
-          "format" : "byte"
-        },
-        "nano" : {
-          "type" : "integer",
-          "format" : "int32"
-        }
-      },
-      "required" : [ "hour", "minute", "second", "nano" ]
-    },
-    "ActionInvocationConfirmation" : {
-      "type" : "object",
-      "properties" : {
-        "actionInvocationId" : {
-          "type" : "string",
-          "format" : "uuid"
-        }
-      },
-      "required" : [ "actionInvocationId" ]
     },
     "DownloadPrepareRequestDTO" : {
       "type" : "object",
@@ -10631,50 +8285,6 @@
         }
       }
     },
-    "CreditCardTokenDTO" : {
-      "type" : "object",
-      "description" : "Stripe Token ID",
-      "properties" : {
-        "token" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "token" ]
-    },
-    "Action" : {
-      "type" : "object",
-      "properties" : {
-        "id" : {
-          "type" : "string",
-          "format" : "uuid"
-        },
-        "name" : {
-          "type" : "string"
-        }
-      },
-      "required" : [ "id", "name" ]
-    },
-    "ChartSetParams" : {
-      "type" : "object",
-      "properties" : {
-        "name" : {
-          "type" : "string"
-        },
-        "charts" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/ChartDefinition"
-          }
-        },
-        "defaultChartsEnabled" : {
-          "type" : "boolean"
-        },
-        "isEditable" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "name" ]
-    },
     "SubscriptionCancelInfoDTO" : {
       "type" : "object",
       "properties" : {
@@ -10702,14 +8312,44 @@
       },
       "required" : [ "userId", "role" ]
     },
-    "DownloadPaymentInfo" : {
+    "QuestionnaireDTO" : {
       "type" : "object",
       "properties" : {
-        "userPaymentSource" : {
-          "$ref" : "#/definitions/UserPaymentSource"
+        "answers" : {
+          "type" : "string"
         }
       },
-      "required" : [ "userPaymentSource" ]
+      "required" : [ "answers" ]
+    },
+    "NewReservationDTO" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        }
+      },
+      "required" : [ "name" ]
+    },
+    "ChartSetParams" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "charts" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ChartDefinition"
+          }
+        },
+        "defaultChartsEnabled" : {
+          "type" : "boolean"
+        },
+        "isEditable" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "name" ]
     },
     "NeptuneOauthToken" : {
       "type" : "object",
@@ -10740,6 +8380,40 @@
         }
       }
     },
+    "ProjectMetadataDTO" : {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "organizationType" : {
+          "$ref" : "#/definitions/OrganizationTypeDTO"
+        },
+        "timeOfCreation" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "organizationName" : {
+          "type" : "string"
+        },
+        "version" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "projectKey" : {
+          "type" : "string"
+        },
+        "organizationId" : {
+          "type" : "string",
+          "format" : "uuid"
+        }
+      },
+      "required" : [ "id", "organizationId", "projectKey", "name", "timeOfCreation", "organizationName", "organizationType", "version" ]
+    },
     "Status" : {
       "type" : "object",
       "properties" : { }
@@ -10752,19 +8426,6 @@
         }
       },
       "required" : [ "url" ]
-    },
-    "StorageLocation" : {
-      "type" : "object",
-      "properties" : {
-        "path" : {
-          "type" : "string"
-        },
-        "size" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      },
-      "required" : [ "path", "size" ]
     }
   },
   "securityDefinitions" : {

--- a/packages/neptune-extension/src/api-spec/leaderboard-swagger.json
+++ b/packages/neptune-extension/src/api-spec/leaderboard-swagger.json
@@ -7,21 +7,1363 @@
     "termsOfService" : "Terms of service",
     "contact" : {
       "name" : "Neptune",
-      "url" : "https://neptune.ai",
-      "email" : "contact@neptune.ai"
+      "url" : "https://neptune.ml",
+      "email" : "contact@neptune.ml"
     },
     "license" : { }
   },
   "host" : "localhost:8070",
   "basePath" : "/",
   "tags" : [ {
+    "name" : "admin",
+    "description" : "Provides admin api"
+  }, {
+    "name" : "experiments",
+    "description" : "Provides experiments api"
+  }, {
     "name" : "leaderboard",
-    "description" : "Provides leaderboard api"
+    "description" : "Provides alias api"
   }, {
     "name" : "notebooks",
     "description" : "Provides notebooks api"
   } ],
   "paths" : {
+    "/api/backend/v1/channels/values" : {
+      "post" : {
+        "summary" : "Add values to channel",
+        "operationId" : "postChannelValues",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "channelsValues",
+          "description" : "channelsValues",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/InputChannelValues"
+            }
+          }
+        }, {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/BatchChannelValueError"
+              }
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/admin/leaderboard/refresh" : {
+      "post" : {
+        "summary" : "Refresh leaderboard",
+        "operationId" : "refreshLeaderboard",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "organizationIdentifiers",
+          "description" : "organizationIdentifiers",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/aliases/" : {
+      "get" : {
+        "summary" : "List project aliases",
+        "operationId" : "listProjectAliases",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/Alias"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "post" : {
+        "summary" : "Create alias",
+        "operationId" : "createAlias",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "aliasToCreate",
+          "description" : "aliasToCreate",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/AliasParams"
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Alias"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/aliases/{aliasId}" : {
+      "get" : {
+        "summary" : "Get alias",
+        "operationId" : "getAlias",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "aliasId",
+          "in" : "path",
+          "description" : "aliasId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Alias"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "put" : {
+        "summary" : "Update alias",
+        "operationId" : "updateAlias",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "aliasId",
+          "in" : "path",
+          "description" : "aliasId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "in" : "body",
+          "name" : "aliasToUpdate",
+          "description" : "aliasToUpdate",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/AliasParams"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Alias"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "delete" : {
+        "summary" : "Delete alias",
+        "operationId" : "deleteAlias",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "aliasId",
+          "in" : "path",
+          "description" : "aliasId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/audit" : {
+      "get" : {
+        "summary" : "Get organization audit data",
+        "operationId" : "getAuditInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "in" : "query",
+          "description" : "organizationIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "username",
+          "in" : "query",
+          "description" : "username",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/AuditInfo"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/user" : {
+      "post" : {
+        "summary" : "Create channel in experiment",
+        "operationId" : "createChannel",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "channelToCreate",
+          "description" : "channelToCreate",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/ChannelParams"
+          }
+        }, {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Channel"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/values" : {
+      "post" : {
+        "summary" : "Add values to channel",
+        "operationId" : "addChannelValues",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "channelsValues",
+          "description" : "channelsValues",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/InputChannelValues"
+            }
+          }
+        }, {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/BatchChannelValueError"
+              }
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/view" : {
+      "post" : {
+        "summary" : "Get series view by channel UUIDs",
+        "operationId" : "getSeriesView",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "pointCount",
+          "in" : "query",
+          "description" : "pointCount",
+          "required" : false,
+          "type" : "integer",
+          "default" : 1000,
+          "format" : "int32"
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "request",
+          "description" : "request",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/SeriesViewRequestDTO"
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/SeriesViewListDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/{channelId}/csv" : {
+      "get" : {
+        "summary" : "Get values of a channel",
+        "operationId" : "getChannelValuesCSV",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "channelId",
+          "in" : "path",
+          "description" : "channelId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "gzipped",
+          "in" : "query",
+          "description" : "gzipped",
+          "required" : false,
+          "type" : "boolean"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/{channelId}/values" : {
+      "get" : {
+        "summary" : "Get values of a channel",
+        "operationId" : "getChannelValues",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "channelId",
+          "in" : "path",
+          "description" : "channelId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "limit",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "description" : "offset",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int32"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LimitedChannelValuesDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/channels/{id}/values" : {
+      "delete" : {
+        "summary" : "Delete values from channel",
+        "operationId" : "resetChannel",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "id",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/download/downloadFile" : {
+      "get" : {
+        "summary" : "Get download stream",
+        "operationId" : "download",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "query",
+          "description" : "id",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/download/downloadRequest" : {
+      "get" : {
+        "summary" : "Get download request",
+        "operationId" : "getDownloadPrepareRequest",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "query",
+          "description" : "id",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/DownloadPrepareRequest"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments" : {
+      "get" : {
+        "summary" : "Get experiment",
+        "operationId" : "getExperiment",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/RichExperiment"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "post" : {
+        "summary" : "Create experiment",
+        "operationId" : "createExperiment",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "X-Neptune-CliVersion",
+          "in" : "header",
+          "description" : "X-Neptune-CliVersion",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "experimentCreationParams",
+          "description" : "experimentCreationParams",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/ExperimentCreationParams"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/Experiment"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "patch" : {
+        "summary" : "Update experiment",
+        "operationId" : "updateExperiment",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "experimentUpdate",
+          "description" : "experimentUpdate",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/EditExperimentParams"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/RichExperiment"
+            }
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments-attributes-names" : {
+      "get" : {
+        "summary" : "getExperimentsAttributesNames",
+        "operationId" : "getExperimentsAttributesNames",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ExperimentsAttributesNamesDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/abort" : {
+      "post" : {
+        "summary" : "Abort experiment",
+        "operationId" : "abortExperiments",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "experimentIdentifiers",
+          "description" : "experimentIdentifiers",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "markOnly",
+          "in" : "query",
+          "description" : "markOnly",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/details" : {
+      "get" : {
+        "summary" : "Get experiment details",
+        "operationId" : "getExperimentDetails",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ExperimentDetails"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/markCompleted" : {
+      "post" : {
+        "summary" : "Mark experiment completed",
+        "operationId" : "markExperimentCompleted",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "completedExperimentParams",
+          "description" : "completedExperimentParams",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/CompletedExperimentParams"
+          }
+        }, {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/ping" : {
+      "post" : {
+        "summary" : "Ping experiment",
+        "operationId" : "pingExperiment",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "query",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/select" : {
+      "post" : {
+        "summary" : "Validate experiments clipboard",
+        "operationId" : "validateExperimentsClipboard",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "experimentIdentifiers",
+          "description" : "experimentIdentifiers",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "trashed",
+          "in" : "query",
+          "description" : "trashed",
+          "required" : true,
+          "type" : "boolean"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/tags" : {
+      "get" : {
+        "summary" : "Get tags defined in experiments within project",
+        "operationId" : "tagsGet",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "trashed",
+          "in" : "query",
+          "description" : "trashed",
+          "required" : false,
+          "type" : "string",
+          "default" : "all",
+          "enum" : [ "false", "true", "all" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "put" : {
+        "summary" : "Update tags in experiments (deprecated)",
+        "operationId" : "updateTags",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "updateTagsParams",
+          "description" : "updateTagsParams",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/UpdateTagsParamsDeprecatedDTO"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/tags2" : {
+      "put" : {
+        "summary" : "Update tags in experiments",
+        "operationId" : "updateTags2",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "updateTagsParams",
+          "description" : "updateTagsParams",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/UpdateTagsParams"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/trash" : {
+      "post" : {
+        "summary" : "Trash experiments",
+        "operationId" : "trashExperiments",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "experimentIdentifiers",
+          "description" : "experimentIdentifiers",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/trash/empty" : {
+      "post" : {
+        "summary" : "Empty experiments trash",
+        "operationId" : "emptyExperimentsTrash",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "experimentIdentifiers",
+          "description" : "experimentIdentifiers",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/experiments/trash/restore" : {
+      "post" : {
+        "summary" : "Restore experiments from trash",
+        "operationId" : "restoreExperiments",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "experimentIdentifiers",
+          "description" : "experimentIdentifiers",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/BulkOpResultDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/images/{experimentId}/{channelId}/{fileName}" : {
+      "get" : {
+        "summary" : "Get image",
+        "operationId" : "getChannelImage",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "channelId",
+          "in" : "path",
+          "description" : "channelId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "experimentId",
+          "in" : "path",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        }, {
+          "name" : "fileName",
+          "in" : "path",
+          "description" : "fileName",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
     "/api/leaderboard/v1/leaderboard" : {
       "get" : {
         "summary" : "Get leaderboard",
@@ -47,6 +1389,13 @@
           },
           "collectionFormat" : "multi"
         }, {
+          "name" : "customView",
+          "in" : "query",
+          "description" : "customView",
+          "required" : false,
+          "type" : "boolean",
+          "default" : false
+        }, {
           "name" : "endDate",
           "in" : "query",
           "required" : false,
@@ -58,11 +1407,9 @@
           "required" : false,
           "type" : "array",
           "items" : {
-            "type" : "string",
-            "enum" : [ "experiment", "notebook" ]
+            "type" : "string"
           },
-          "collectionFormat" : "multi",
-          "enum" : [ "experiment", "notebook" ]
+          "collectionFormat" : "multi"
         }, {
           "name" : "filterId",
           "in" : "query",
@@ -73,8 +1420,38 @@
           "name" : "flattingMode",
           "in" : "query",
           "required" : false,
-          "type" : "string",
-          "enum" : [ "all", "standaloneOnly", "inGroupOnly" ]
+          "type" : "string"
+        }, {
+          "name" : "groupBy",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        }, {
+          "name" : "groupByFieldAggregationMode",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+        }, {
+          "name" : "groupByFieldType",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
         }, {
           "name" : "groupId",
           "in" : "query",
@@ -134,8 +1511,18 @@
           "type" : "integer",
           "format" : "int32"
         }, {
+          "name" : "openedGroups",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        }, {
           "name" : "organizationIdentifier",
           "in" : "query",
+          "description" : "organizationIdentifier",
           "required" : false,
           "type" : "string"
         }, {
@@ -150,6 +1537,7 @@
         }, {
           "name" : "projectIdentifier",
           "in" : "query",
+          "description" : "projectIdentifier",
           "required" : false,
           "type" : "string"
         }, {
@@ -196,16 +1584,34 @@
           "collectionFormat" : "multi",
           "enum" : [ "ascending", "descending" ]
         }, {
+          "name" : "sortFieldAggregationMode",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+        }, {
           "name" : "sortFieldType",
           "in" : "query",
           "required" : false,
           "type" : "array",
           "items" : {
             "type" : "string",
-            "enum" : [ "native", "parameter", "numericChannel", "textChannel", "property" ]
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
           },
           "collectionFormat" : "multi",
-          "enum" : [ "native", "parameter", "numericChannel", "textChannel", "property" ]
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        }, {
+          "name" : "sourceViewId",
+          "in" : "query",
+          "description" : "sourceViewId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
         }, {
           "name" : "startDate",
           "in" : "query",
@@ -244,6 +1650,13 @@
           "required" : false,
           "type" : "string",
           "enum" : [ "false", "true", "all" ]
+        }, {
+          "name" : "viewId",
+          "in" : "query",
+          "description" : "viewId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
         } ],
         "responses" : {
           "200" : {
@@ -252,38 +1665,8 @@
               "$ref" : "#/definitions/LeaderboardDTO"
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not Found"
-          }
-        },
-        "deprecated" : false
-      }
-    },
-    "/api/leaderboard/v1/namedFilters/{namedFilterId}" : {
-      "get" : {
-        "summary" : "Get named filter by id",
-        "operationId" : "getNamedFilter",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "namedFilterId",
-          "in" : "path",
-          "description" : "namedFilterId",
-          "required" : true,
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/NamedFilterDTO"
-            }
+          "400" : {
+            "description" : "Bad Request"
           },
           "401" : {
             "description" : "Unauthorized"
@@ -293,71 +1676,6 @@
           },
           "404" : {
             "description" : "Not Found"
-          }
-        },
-        "deprecated" : false
-      },
-      "delete" : {
-        "summary" : "Delete named filter by id",
-        "operationId" : "deleteNamedFilter",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "namedFilterId",
-          "in" : "path",
-          "description" : "namedFilterId",
-          "required" : true,
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
-          "204" : {
-            "description" : "No Content"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        },
-        "deprecated" : false
-      },
-      "patch" : {
-        "summary" : "Update named filter by id",
-        "operationId" : "updateNamedFilter",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "namedFilterId",
-          "in" : "path",
-          "description" : "namedFilterId",
-          "required" : true,
-          "type" : "string",
-          "format" : "uuid"
-        }, {
-          "in" : "body",
-          "name" : "namedFilterUpdate",
-          "description" : "namedFilterUpdate",
-          "required" : true,
-          "schema" : {
-            "$ref" : "#/definitions/NamedFilterUpdateDTO"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/NamedFilterDTO"
-            }
-          },
-          "204" : {
-            "description" : "No Content"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
           }
         },
         "deprecated" : false
@@ -601,7 +1919,7 @@
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "name" : "id",
-          "in" : "query",
+          "in" : "path",
           "description" : "id",
           "required" : true,
           "type" : "string",
@@ -707,7 +2025,10 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
           },
           "401" : {
             "description" : "Unauthorized"
@@ -776,7 +2097,10 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK"
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
           },
           "401" : {
             "description" : "Unauthorized"
@@ -823,6 +2147,31 @@
         },
         "deprecated" : false
       },
+      "delete" : {
+        "summary" : "Delete notebook",
+        "operationId" : "deleteNotebook",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "id",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      },
       "patch" : {
         "summary" : "Update notebook",
         "operationId" : "updateNotebook",
@@ -851,33 +2200,6 @@
               "$ref" : "#/definitions/NotebookDTO"
             }
           },
-          "204" : {
-            "description" : "No Content"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        },
-        "deprecated" : false
-      }
-    },
-    "/api/leaderboard/v1/notebooks/{id}/content" : {
-      "delete" : {
-        "summary" : "Delete notebook",
-        "operationId" : "deleteNotebook",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "id",
-          "in" : "path",
-          "description" : "id",
-          "required" : true,
-          "type" : "string",
-          "format" : "uuid"
-        } ],
-        "responses" : {
           "204" : {
             "description" : "No Content"
           },
@@ -991,146 +2313,33 @@
         "deprecated" : false
       }
     },
-    "/api/leaderboard/v1/organizations/{organizationName}/projects/{projectName}/namedFilters" : {
-      "get" : {
-        "summary" : "List named filters for project",
-        "operationId" : "listNamedFilters",
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "organizationName",
-          "in" : "path",
-          "description" : "organizationName",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "projectName",
-          "in" : "path",
-          "description" : "projectName",
-          "required" : true,
-          "type" : "string"
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "type" : "array",
-              "items" : {
-                "$ref" : "#/definitions/NamedFilterDTO"
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not Found"
-          }
-        },
-        "deprecated" : false
-      },
+    "/api/leaderboard/v1/prepareForDownloadLeaderboardCsv" : {
       "post" : {
-        "summary" : "Create a named filter",
-        "operationId" : "createNamedFilter",
+        "summary" : "Prepare download leaderboard as CSV",
+        "operationId" : "prepareForDownloadLeaderboardCsv",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
           "in" : "body",
-          "name" : "namedFilterParams",
-          "description" : "namedFilterParams",
+          "name" : "csvExporting",
+          "description" : "csvExporting",
           "required" : true,
           "schema" : {
-            "$ref" : "#/definitions/NamedFilterParamsDTO"
+            "$ref" : "#/definitions/LeaderboardCsvExportParamsDTO"
           }
         }, {
-          "name" : "organizationName",
-          "in" : "path",
-          "description" : "organizationName",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "projectName",
-          "in" : "path",
-          "description" : "projectName",
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
           "required" : true,
           "type" : "string"
         } ],
         "responses" : {
-          "200" : {
-            "description" : "OK",
-            "schema" : {
-              "$ref" : "#/definitions/NamedFilterDTO"
-            }
-          },
           "201" : {
-            "description" : "Created"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not Found"
-          }
-        },
-        "deprecated" : false
-      }
-    },
-    "/api/leaderboard/v1/organizations/{organizationName}/projects/{projectName}/namedFilters/count" : {
-      "post" : {
-        "summary" : "Count matching leaderboard items",
-        "operationId" : "countMatchingLeaderboardEntries",
-        "consumes" : [ "application/json" ],
-        "produces" : [ "application/json" ],
-        "parameters" : [ {
-          "name" : "flattingMode",
-          "in" : "query",
-          "description" : "flattingMode",
-          "required" : false,
-          "type" : "string",
-          "default" : "all",
-          "enum" : [ "all", "standaloneOnly", "inGroupOnly" ]
-        }, {
-          "in" : "body",
-          "name" : "namedFilterParams",
-          "description" : "namedFilterParams",
-          "required" : true,
-          "schema" : {
-            "$ref" : "#/definitions/NamedFilterParamsDTO"
-          }
-        }, {
-          "name" : "organizationName",
-          "in" : "path",
-          "description" : "organizationName",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "projectName",
-          "in" : "path",
-          "description" : "projectName",
-          "required" : true,
-          "type" : "string"
-        }, {
-          "name" : "trashed",
-          "in" : "query",
-          "description" : "trashed",
-          "required" : false,
-          "type" : "boolean",
-          "default" : false
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
+            "description" : "Created",
             "schema" : {
-              "$ref" : "#/definitions/LeaderboardEntryCountDTO"
+              "$ref" : "#/definitions/DownloadPrepareRequest"
             }
-          },
-          "201" : {
-            "description" : "Created"
           },
           "401" : {
             "description" : "Unauthorized"
@@ -1338,24 +2547,224 @@
         "deprecated" : false
       }
     },
-    "/api/leaderboard/v1/projects/{projectId}/settings" : {
-      "get" : {
-        "summary" : "Set project leaderboard settings",
-        "operationId" : "getProjectLeaderboardSettings",
+    "/api/leaderboard/v1/query" : {
+      "post" : {
+        "summary" : "Get leaderboard",
+        "operationId" : "queryLeaderboard",
+        "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
-          "name" : "projectId",
-          "in" : "path",
-          "description" : "projectId",
+          "name" : "groupBy",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        }, {
+          "name" : "groupByFieldAggregationMode",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+        }, {
+          "name" : "groupByFieldType",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "offset",
+          "in" : "query",
+          "required" : false,
+          "type" : "integer",
+          "format" : "int32"
+        }, {
+          "name" : "openedGroups",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
           "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "query",
+          "description" : "query",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/NqlQueryParamsDTO"
+          }
+        }, {
+          "name" : "sortBy",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          },
+          "collectionFormat" : "multi"
+        }, {
+          "name" : "sortDirection",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "ascending", "descending" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "ascending", "descending" ]
+        }, {
+          "name" : "sortFieldAggregationMode",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+        }, {
+          "name" : "sortFieldType",
+          "in" : "query",
+          "required" : false,
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          },
+          "collectionFormat" : "multi",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        }, {
+          "name" : "sourceViewId",
+          "in" : "query",
+          "description" : "sourceViewId",
+          "required" : false,
           "type" : "string",
           "format" : "uuid"
+        }, {
+          "name" : "trashed",
+          "in" : "query",
+          "description" : "trashed",
+          "required" : false,
+          "type" : "string",
+          "default" : "false",
+          "enum" : [ "false", "true", "all" ]
         } ],
         "responses" : {
           "200" : {
             "description" : "OK",
             "schema" : {
-              "$ref" : "#/definitions/ProjectLeaderboardSettingsDTO"
+              "$ref" : "#/definitions/LeaderboardDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/deleteOutput" : {
+      "delete" : {
+        "summary" : "Delete experiment output",
+        "operationId" : "deleteExperimentOutput",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "path",
+          "in" : "query",
+          "description" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/download" : {
+      "get" : {
+        "summary" : "Download project file",
+        "operationId" : "downloadPath",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "pathParam",
+          "in" : "query",
+          "description" : "pathParam",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
             }
           },
           "401" : {
@@ -1369,34 +2778,516 @@
           }
         },
         "deprecated" : false
-      },
+      }
+    },
+    "/api/leaderboard/v1/storage/downloadRequest" : {
       "post" : {
-        "summary" : "Set project leaderboard settings",
-        "operationId" : "setProjectLeaderboardSettings",
+        "summary" : "Prepare directory download",
+        "operationId" : "prepareForDownload",
         "consumes" : [ "application/json" ],
         "produces" : [ "application/json" ],
         "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "pathParam",
+          "in" : "query",
+          "description" : "pathParam",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "schema" : {
+              "$ref" : "#/definitions/DownloadPrepareRequest"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/experiments/info" : {
+      "get" : {
+        "summary" : "Get experiment storage info",
+        "operationId" : "getExperimentStorageInfo",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/ExperimentStorageInfoDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/download" : {
+      "get" : {
+        "summary" : "legacyDownloadData",
+        "operationId" : "legacyDownloadDataUsingGET",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "path",
+          "in" : "query",
+          "description" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
           "name" : "projectId",
-          "in" : "path",
+          "in" : "query",
           "description" : "projectId",
           "required" : true,
           "type" : "string",
           "format" : "uuid"
-        }, {
-          "in" : "body",
-          "name" : "settings",
-          "description" : "settings",
-          "required" : true,
-          "schema" : {
-            "$ref" : "#/definitions/ProjectLeaderboardSettingsDTO"
-          }
         } ],
         "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "file"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/downloadRequest" : {
+      "post" : {
+        "summary" : "legacyPrepareDownload",
+        "operationId" : "legacyPrepareDownloadUsingPOST",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentity",
+          "in" : "query",
+          "description" : "experimentIdentity",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "path",
+          "in" : "query",
+          "description" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/DownloadPrepareRequest"
+            }
+          },
           "201" : {
             "description" : "Created"
           },
-          "204" : {
-            "description" : "No Content"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadOutput/{experimentId}" : {
+      "post" : {
+        "summary" : "uploadOutput",
+        "operationId" : "uploadOutputUsingPOST",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "path",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadOutputAsTarStream/{experimentId}" : {
+      "post" : {
+        "summary" : "uploadOutputAsTarStream",
+        "operationId" : "uploadOutputAsTarStreamUsingPOST",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "path",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadSource/{experimentId}" : {
+      "post" : {
+        "summary" : "uploadSource",
+        "operationId" : "uploadSourceUsingPOST",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "path",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/storage/legacy/uploadSourceAsTarStream/{experimentId}" : {
+      "post" : {
+        "summary" : "uploadSourceAsTarStream",
+        "operationId" : "uploadSourceAsTarStreamUsingPOST",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentId",
+          "in" : "path",
+          "description" : "experimentId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : true
+      }
+    },
+    "/api/leaderboard/v1/storage/ls" : {
+      "get" : {
+        "summary" : "List project files in a directory",
+        "operationId" : "lsPath",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "pathParam",
+          "in" : "query",
+          "description" : "pathParam",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/FileEntry"
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/upload" : {
+      "post" : {
+        "summary" : "Upload experiment file",
+        "operationId" : "uploadPath",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "pathParam",
+          "in" : "query",
+          "description" : "pathParam",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/uploadTarStream" : {
+      "post" : {
+        "summary" : "Upload experiment files",
+        "operationId" : "uploadTarStream",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "experimentIdentifier",
+          "in" : "query",
+          "description" : "experimentIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "resource",
+          "in" : "query",
+          "description" : "resource",
+          "required" : true,
+          "type" : "string",
+          "enum" : [ "output", "source" ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/storage/usage" : {
+      "get" : {
+        "summary" : "Get storage usage",
+        "operationId" : "storageUsageFixMe",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "organizationIdentifier",
+          "in" : "query",
+          "description" : "organizationIdentifier",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/StorageUsage"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/suggestions/decline" : {
+      "post" : {
+        "summary" : "Decline column suggestion from the project",
+        "operationId" : "suggestionDecline",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "suggestion",
+          "description" : "suggestion",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/LeaderboardFieldSuggestionDTO"
+          }
+        }, {
+          "name" : "viewId",
+          "in" : "query",
+          "description" : "viewId",
+          "required" : false,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "201" : {
+            "description" : "Created"
           },
           "401" : {
             "description" : "Unauthorized"
@@ -1450,6 +3341,234 @@
         "deprecated" : false
       }
     },
+    "/api/leaderboard/v1/views" : {
+      "get" : {
+        "summary" : "List views in project",
+        "operationId" : "listLeaderboardViews",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LeaderboardViewListDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "post" : {
+        "summary" : "Create view in project",
+        "operationId" : "createLeaderboardView",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "createView",
+          "description" : "createView",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/NewLeaderboardViewDTO"
+          }
+        }, {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "schema" : {
+              "$ref" : "#/definitions/LeaderboardViewDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/views/setDefault" : {
+      "post" : {
+        "summary" : "Set default",
+        "operationId" : "setDefaultView",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "setDefaultOperation",
+          "description" : "setDefaultOperation",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/LeaderboardViewSetDefaultDTO"
+          }
+        } ],
+        "responses" : {
+          "201" : {
+            "description" : "Created"
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      }
+    },
+    "/api/leaderboard/v1/views/{viewId}" : {
+      "get" : {
+        "summary" : "Get view",
+        "operationId" : "getLeaderboardView",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "viewId",
+          "in" : "path",
+          "description" : "viewId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LeaderboardViewDTO"
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "put" : {
+        "summary" : "Update view",
+        "operationId" : "updateLeaderboardView",
+        "consumes" : [ "application/json" ],
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "in" : "body",
+          "name" : "updateView",
+          "description" : "updateView",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/LeaderboardViewUpdateDTO"
+          }
+        }, {
+          "name" : "viewId",
+          "in" : "path",
+          "description" : "viewId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "schema" : {
+              "$ref" : "#/definitions/LeaderboardViewDTO"
+            }
+          },
+          "201" : {
+            "description" : "Created"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "404" : {
+            "description" : "Not Found"
+          }
+        },
+        "deprecated" : false
+      },
+      "delete" : {
+        "summary" : "Delete view",
+        "operationId" : "deleteLeaderboardView",
+        "produces" : [ "application/json" ],
+        "parameters" : [ {
+          "name" : "projectIdentifier",
+          "in" : "query",
+          "description" : "projectIdentifier",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "viewId",
+          "in" : "path",
+          "description" : "viewId",
+          "required" : true,
+          "type" : "string",
+          "format" : "uuid"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "204" : {
+            "description" : "No Content"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "deprecated" : false
+      }
+    },
     "/api/leaderboard/v1/{organizationId}/running" : {
       "get" : {
         "summary" : "Get running entries in organization with costs",
@@ -1485,24 +3604,163 @@
     }
   },
   "definitions" : {
-    "BooleanFilterDTO" : {
+    "Alias" : {
       "type" : "object",
-      "required" : [ "value", "verb" ],
+      "required" : [ "channels", "id", "name", "projectId" ],
       "properties" : {
-        "value" : {
-          "type" : "boolean"
+        "channels" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
-        "verb" : {
+        "id" : {
           "type" : "string",
-          "enum" : [ "is" ]
+          "format" : "uuid"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
         }
       },
-      "title" : "BooleanFilterDTO"
+      "title" : "Alias"
+    },
+    "AliasParams" : {
+      "type" : "object",
+      "required" : [ "channels", "name" ],
+      "properties" : {
+        "channels" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "name" : {
+          "type" : "string"
+        }
+      },
+      "title" : "AliasParams"
+    },
+    "AuditInfo" : {
+      "type" : "object",
+      "properties" : {
+        "accustomedExperimentCreatedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "firstExperimentCreatedAt" : {
+          "type" : "string",
+          "format" : "date-time"
+        }
+      },
+      "title" : "AuditInfo"
+    },
+    "BatchChannelValueError" : {
+      "type" : "object",
+      "required" : [ "channelId", "error", "x" ],
+      "properties" : {
+        "channelId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "error" : {
+          "$ref" : "#/definitions/Error"
+        },
+        "x" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      },
+      "title" : "BatchChannelValueError"
+    },
+    "BulkOpErrorDTO" : {
+      "type" : "object",
+      "required" : [ "experiment", "message", "reason" ],
+      "properties" : {
+        "experiment" : {
+          "description" : "Experiment identifiers.",
+          "$ref" : "#/definitions/ExperimentIdentifiersDTO"
+        },
+        "message" : {
+          "type" : "string",
+          "description" : "Error message."
+        },
+        "reason" : {
+          "type" : "string",
+          "description" : "Error reason.",
+          "enum" : [ "TRASHED", "ALREADY_TRASHED", "NOT_EXISTS", "NOT_IN_TRASH", "ALREADY_FINISHED" ]
+        }
+      },
+      "title" : "BulkOpErrorDTO"
+    },
+    "BulkOpResultDTO" : {
+      "type" : "object",
+      "required" : [ "errors", "updated" ],
+      "properties" : {
+        "errors" : {
+          "type" : "array",
+          "description" : "Errors.",
+          "items" : {
+            "$ref" : "#/definitions/BulkOpErrorDTO"
+          }
+        },
+        "updated" : {
+          "type" : "array",
+          "description" : "The entries updated successfully.",
+          "items" : {
+            "$ref" : "#/definitions/ExperimentIdentifiersDTO"
+          }
+        }
+      },
+      "title" : "BulkOpResultDTO"
+    },
+    "Channel" : {
+      "type" : "object",
+      "required" : [ "channelType", "id", "name" ],
+      "properties" : {
+        "channelType" : {
+          "type" : "string",
+          "enum" : [ "numeric", "text", "image" ]
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "lastX" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "name" : {
+          "type" : "string"
+        }
+      },
+      "title" : "Channel"
+    },
+    "ChannelParams" : {
+      "type" : "object",
+      "required" : [ "channelType", "name" ],
+      "properties" : {
+        "channelType" : {
+          "type" : "string",
+          "enum" : [ "numeric", "text", "image" ]
+        },
+        "name" : {
+          "type" : "string"
+        }
+      },
+      "title" : "ChannelParams"
     },
     "ChannelWithValueDTO" : {
       "type" : "object",
       "required" : [ "channelId", "channelName", "channelType", "x", "y" ],
       "properties" : {
+        "averageY" : {
+          "type" : "number",
+          "format" : "double"
+        },
         "channelId" : {
           "type" : "string",
           "format" : "uuid"
@@ -1513,6 +3771,18 @@
         "channelType" : {
           "type" : "string",
           "enum" : [ "numeric", "text", "image" ]
+        },
+        "maxY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "minY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "varianceY" : {
+          "type" : "number",
+          "format" : "double"
         },
         "x" : {
           "type" : "number",
@@ -1598,83 +3868,224 @@
       },
       "title" : "CheckpointUpdateDTO"
     },
-    "DateTimeDurationFilterDTO" : {
+    "CompletedExperimentParams" : {
       "type" : "object",
-      "required" : [ "value", "verb" ],
+      "required" : [ "state" ],
       "properties" : {
-        "value" : {
-          "$ref" : "#/definitions/TimeDurationDTO"
-        },
-        "verb" : {
-          "type" : "string",
-          "enum" : [ "isOverTheLast" ]
-        }
-      },
-      "title" : "DateTimeDurationFilterDTO"
-    },
-    "DateTimeFilterDTO" : {
-      "type" : "object",
-      "properties" : {
-        "durationFilter" : {
-          "$ref" : "#/definitions/DateTimeDurationFilterDTO"
-        },
-        "intervalFilter" : {
-          "$ref" : "#/definitions/DateTimeIntervalFilterDTO"
-        },
-        "valueFilter" : {
-          "$ref" : "#/definitions/DateTimeValueFilterDTO"
-        }
-      },
-      "title" : "DateTimeFilterDTO"
-    },
-    "DateTimeIntervalFilterDTO" : {
-      "type" : "object",
-      "required" : [ "from", "to", "verb" ],
-      "properties" : {
-        "from" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "to" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "verb" : {
-          "type" : "string",
-          "enum" : [ "isBetween", "isNotBetween" ]
-        }
-      },
-      "title" : "DateTimeIntervalFilterDTO"
-    },
-    "DateTimeValueFilterDTO" : {
-      "type" : "object",
-      "required" : [ "value", "verb" ],
-      "properties" : {
-        "value" : {
-          "type" : "string",
-          "format" : "date-time"
-        },
-        "verb" : {
-          "type" : "string",
-          "enum" : [ "is", "isNot", "isAfter", "isBefore" ]
-        }
-      },
-      "title" : "DateTimeValueFilterDTO"
-    },
-    "ExperimentStateFilterDTO" : {
-      "type" : "object",
-      "required" : [ "value", "verb" ],
-      "properties" : {
-        "value" : {
+        "state" : {
           "type" : "string",
           "enum" : [ "running", "succeeded", "aborted", "failed" ]
         },
-        "verb" : {
-          "type" : "string",
-          "enum" : [ "is", "isNot" ]
+        "traceback" : {
+          "type" : "string"
         }
       },
-      "title" : "ExperimentStateFilterDTO"
+      "title" : "CompletedExperimentParams"
+    },
+    "ComponentVersion" : {
+      "type" : "object",
+      "required" : [ "name", "version" ],
+      "properties" : {
+        "name" : {
+          "type" : "string",
+          "enum" : [ "Client" ]
+        },
+        "version" : {
+          "type" : "string"
+        }
+      },
+      "title" : "ComponentVersion"
+    },
+    "DirectoryInfo" : {
+      "type" : "object",
+      "required" : [ "size" ],
+      "properties" : {
+        "mtime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "title" : "DirectoryInfo"
+    },
+    "DownloadPrepareRequest" : {
+      "type" : "object",
+      "required" : [ "id" ],
+      "properties" : {
+        "downloadUrl" : {
+          "type" : "string"
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        }
+      },
+      "title" : "DownloadPrepareRequest"
+    },
+    "EditExperimentParams" : {
+      "type" : "object",
+      "properties" : {
+        "description" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/KeyValueProperty"
+          }
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "EditExperimentParams"
+    },
+    "Error" : {
+      "type" : "object",
+      "required" : [ "code", "message" ],
+      "properties" : {
+        "code" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "message" : {
+          "type" : "string"
+        }
+      },
+      "title" : "Error"
+    },
+    "Experiment" : {
+      "type" : "object",
+      "required" : [ "id", "shortId" ],
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "shortId" : {
+          "type" : "string"
+        }
+      },
+      "title" : "Experiment"
+    },
+    "ExperimentCreationParams" : {
+      "type" : "object",
+      "required" : [ "name", "parameters", "properties", "tags" ],
+      "properties" : {
+        "abortable" : {
+          "type" : "boolean"
+        },
+        "checkpointId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "enqueueCommand" : {
+          "type" : "string"
+        },
+        "entrypoint" : {
+          "type" : "string"
+        },
+        "execArgsTemplate" : {
+          "type" : "string"
+        },
+        "gitInfo" : {
+          "$ref" : "#/definitions/GitInfoDTO"
+        },
+        "hostname" : {
+          "type" : "string"
+        },
+        "monitored" : {
+          "type" : "boolean"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "notebookId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "parameters" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Parameter"
+          }
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "projectIdentifier" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/KeyValueProperty"
+          }
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "ExperimentCreationParams"
+    },
+    "ExperimentDetails" : {
+      "type" : "object",
+      "required" : [ "id" ],
+      "properties" : {
+        "gitInfo" : {
+          "$ref" : "#/definitions/GitInfoDTO"
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        }
+      },
+      "title" : "ExperimentDetails"
+    },
+    "ExperimentIdentifiersDTO" : {
+      "type" : "object",
+      "required" : [ "id", "qualifiedName" ],
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid",
+          "description" : "UUID"
+        },
+        "qualifiedName" : {
+          "type" : "string",
+          "description" : "Qualified name."
+        }
+      },
+      "title" : "ExperimentIdentifiersDTO"
+    },
+    "ExperimentPaths" : {
+      "type" : "object",
+      "required" : [ "output", "source" ],
+      "properties" : {
+        "output" : {
+          "type" : "string"
+        },
+        "source" : {
+          "type" : "string"
+        }
+      },
+      "title" : "ExperimentPaths"
     },
     "ExperimentStatesDTO" : {
       "type" : "object",
@@ -1703,45 +4114,170 @@
       },
       "title" : "ExperimentStatesDTO"
     },
-    "FilteringConditionDTO" : {
+    "ExperimentStorageInfoDTO" : {
       "type" : "object",
+      "required" : [ "artifacts", "sources" ],
       "properties" : {
-        "name" : {
-          "$ref" : "#/definitions/StringFilterDTO"
+        "artifacts" : {
+          "$ref" : "#/definitions/DirectoryInfo"
         },
-        "ownerName" : {
-          "$ref" : "#/definitions/StringFilterDTO"
-        },
-        "responding" : {
-          "$ref" : "#/definitions/BooleanFilterDTO"
-        },
-        "state" : {
-          "$ref" : "#/definitions/ExperimentStateFilterDTO"
-        },
-        "tags" : {
-          "$ref" : "#/definitions/TagsFilterDTO"
-        },
-        "timeOfCreation" : {
-          "$ref" : "#/definitions/DateTimeFilterDTO"
+        "sources" : {
+          "$ref" : "#/definitions/DirectoryInfo"
         }
       },
-      "title" : "FilteringConditionDTO"
+      "title" : "ExperimentStorageInfoDTO"
     },
-    "FilteringConditionsDTO" : {
+    "ExperimentsAttributesNamesDTO" : {
       "type" : "object",
-      "required" : [ "filtersInDisjunctiveForm" ],
+      "required" : [ "numericChannelsNames", "numericParametersNames", "propertiesNames", "textChannelsNames", "textParametersNames" ],
       "properties" : {
-        "filtersInDisjunctiveForm" : {
+        "numericChannelsNames" : {
           "type" : "array",
           "items" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/definitions/FilteringConditionDTO"
-            }
+            "type" : "string"
+          }
+        },
+        "numericParametersNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "propertiesNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "textChannelsNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "textParametersNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
           }
         }
       },
-      "title" : "FilteringConditionsDTO"
+      "title" : "ExperimentsAttributesNamesDTO"
+    },
+    "FileEntry" : {
+      "type" : "object",
+      "required" : [ "fileType", "mtime", "name" ],
+      "properties" : {
+        "fileType" : {
+          "type" : "string"
+        },
+        "mtime" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "size" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "title" : "FileEntry"
+    },
+    "GitCommitDTO" : {
+      "type" : "object",
+      "required" : [ "authorEmail", "authorName", "commitDate", "commitId", "message" ],
+      "properties" : {
+        "authorEmail" : {
+          "type" : "string"
+        },
+        "authorName" : {
+          "type" : "string"
+        },
+        "commitDate" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "commitId" : {
+          "type" : "string"
+        },
+        "message" : {
+          "type" : "string"
+        }
+      },
+      "title" : "GitCommitDTO"
+    },
+    "GitInfoDTO" : {
+      "type" : "object",
+      "required" : [ "commit", "repositoryDirty" ],
+      "properties" : {
+        "commit" : {
+          "$ref" : "#/definitions/GitCommitDTO"
+        },
+        "currentBranch" : {
+          "type" : "string"
+        },
+        "remotes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "repositoryDirty" : {
+          "type" : "boolean"
+        }
+      },
+      "title" : "GitInfoDTO"
+    },
+    "InputChannelValues" : {
+      "type" : "object",
+      "required" : [ "channelId", "values" ],
+      "properties" : {
+        "channelId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Point"
+          }
+        }
+      },
+      "title" : "InputChannelValues"
+    },
+    "InputImage" : {
+      "type" : "object",
+      "properties" : {
+        "data" : {
+          "type" : "string"
+        },
+        "description" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        }
+      },
+      "title" : "InputImage"
+    },
+    "InputStream" : {
+      "type" : "object",
+      "title" : "InputStream"
+    },
+    "KeyValueProperty" : {
+      "type" : "object",
+      "required" : [ "key", "value" ],
+      "properties" : {
+        "key" : {
+          "type" : "string"
+        },
+        "value" : {
+          "type" : "string"
+        }
+      },
+      "title" : "KeyValueProperty"
     },
     "KeyValuePropertyDTO" : {
       "type" : "object",
@@ -1756,6 +4292,55 @@
       },
       "title" : "KeyValuePropertyDTO"
     },
+    "LeaderboardCsvExportParamsDTO" : {
+      "type" : "object",
+      "required" : [ "exportFieldAggregations", "exportFieldNames", "exportFieldTypes", "exportFields", "zoneOffset" ],
+      "properties" : {
+        "exportFieldAggregations" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          }
+        },
+        "exportFieldNames" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "exportFieldTypes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          }
+        },
+        "exportFields" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "filtering" : {
+          "$ref" : "#/definitions/LeaderboardFilterParamsDTO"
+        },
+        "query" : {
+          "type" : "string"
+        },
+        "sorting" : {
+          "$ref" : "#/definitions/LeaderboardSortParamsDTO"
+        },
+        "zoneOffset" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "zoneRegion" : {
+          "type" : "string"
+        }
+      },
+      "title" : "LeaderboardCsvExportParamsDTO"
+    },
     "LeaderboardDTO" : {
       "type" : "object",
       "required" : [ "entries", "matchingItemCount", "totalItemCount" ],
@@ -1767,10 +4352,29 @@
             "$ref" : "#/definitions/LeaderboardEntryDTO"
           }
         },
+        "groups" : {
+          "type" : "array",
+          "description" : "The groups of entities matching given criteria.",
+          "items" : {
+            "$ref" : "#/definitions/LeaderboardEntryGroupDTO"
+          }
+        },
         "matchingItemCount" : {
           "type" : "integer",
           "format" : "int64",
           "description" : "The total number of entries matching the given criteria."
+        },
+        "suggestions" : {
+          "type" : "array",
+          "description" : "The column suggestions to the user, most recommended columns first.",
+          "items" : {
+            "$ref" : "#/definitions/LeaderboardFieldSuggestionDTO"
+          }
+        },
+        "totalGroupCount" : {
+          "type" : "integer",
+          "format" : "int32",
+          "description" : "The total number of group entries."
         },
         "totalItemCount" : {
           "type" : "integer",
@@ -1780,24 +4384,9 @@
       },
       "title" : "LeaderboardDTO"
     },
-    "LeaderboardEntryCountDTO" : {
-      "type" : "object",
-      "required" : [ "matchingItemCount", "totalItemCount" ],
-      "properties" : {
-        "matchingItemCount" : {
-          "type" : "integer",
-          "format" : "int64"
-        },
-        "totalItemCount" : {
-          "type" : "integer",
-          "format" : "int64"
-        }
-      },
-      "title" : "LeaderboardEntryCountDTO"
-    },
     "LeaderboardEntryDTO" : {
       "type" : "object",
-      "required" : [ "channelsLastValues", "deleted", "description", "entryType", "experimentStates", "id", "isBestExperiment", "name", "organizationId", "organizationName", "owner", "parameters", "projectDeleted", "projectId", "projectName", "properties", "responding", "runningTime", "shortId", "size", "state", "tags", "timeOfCreation", "trashed" ],
+      "required" : [ "channelsLastValues", "deleted", "description", "entryType", "experimentStates", "id", "name", "organizationId", "organizationName", "owner", "parameters", "projectId", "projectName", "properties", "responding", "runningTime", "shortId", "size", "state", "tags", "timeOfCreation", "trashed" ],
       "properties" : {
         "channelsLastValues" : {
           "type" : "array",
@@ -1829,8 +4418,7 @@
           "type" : "string"
         },
         "entryType" : {
-          "type" : "string",
-          "enum" : [ "experiment", "notebook" ]
+          "type" : "string"
         },
         "experimentStates" : {
           "$ref" : "#/definitions/ExperimentStatesDTO"
@@ -1841,9 +4429,6 @@
         "id" : {
           "type" : "string",
           "format" : "uuid"
-        },
-        "isBestExperiment" : {
-          "type" : "boolean"
         },
         "name" : {
           "type" : "string"
@@ -1874,9 +4459,6 @@
             "$ref" : "#/definitions/ParameterDTO"
           }
         },
-        "projectDeleted" : {
-          "type" : "boolean"
-        },
         "projectId" : {
           "type" : "string",
           "format" : "uuid"
@@ -1903,7 +4485,7 @@
         "size" : {
           "type" : "integer",
           "format" : "int64",
-          "description" : "The size of all storage files in bytes."
+          "description" : "The size of all storage files, text logs and metrics in bytes."
         },
         "state" : {
           "type" : "string",
@@ -1930,12 +4512,283 @@
       },
       "title" : "LeaderboardEntryDTO"
     },
-    "NamedFilterDTO" : {
+    "LeaderboardEntryGroupDTO" : {
       "type" : "object",
-      "required" : [ "filters", "id", "name" ],
+      "required" : [ "childrenIds", "id", "itemCount", "key" ],
       "properties" : {
-        "filters" : {
-          "$ref" : "#/definitions/FilteringConditionsDTO"
+        "childrenIds" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        },
+        "id" : {
+          "type" : "string",
+          "description" : "ID of the group"
+        },
+        "itemCount" : {
+          "type" : "integer",
+          "format" : "int64",
+          "description" : "The number of entries in the group."
+        },
+        "key" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LeaderboardFieldWithValueDTO"
+          }
+        }
+      },
+      "title" : "LeaderboardEntryGroupDTO"
+    },
+    "LeaderboardFieldDTO" : {
+      "type" : "object",
+      "required" : [ "aggregation", "name", "type" ],
+      "properties" : {
+        "aggregation" : {
+          "type" : "string",
+          "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        }
+      },
+      "title" : "LeaderboardFieldDTO"
+    },
+    "LeaderboardFieldSuggestionDTO" : {
+      "type" : "object",
+      "required" : [ "name", "type" ],
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        }
+      },
+      "title" : "LeaderboardFieldSuggestionDTO"
+    },
+    "LeaderboardFieldWithValueDTO" : {
+      "type" : "object",
+      "required" : [ "field" ],
+      "properties" : {
+        "field" : {
+          "$ref" : "#/definitions/LeaderboardFieldDTO"
+        },
+        "value" : {
+          "type" : "object"
+        }
+      },
+      "title" : "LeaderboardFieldWithValueDTO"
+    },
+    "LeaderboardFilterParamsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "shortId" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "state" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "running", "succeeded", "aborted", "failed" ]
+          }
+        },
+        "owner" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "notebookId" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        },
+        "notebookName" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "checkpointId" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        },
+        "checkpointName" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "startDate" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "endDate" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "searchTerm" : {
+          "type" : "string"
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "tagsMode" : {
+          "type" : "string",
+          "enum" : [ "and", "or" ]
+        },
+        "trashed" : {
+          "type" : "string",
+          "enum" : [ "false", "true", "all" ]
+        },
+        "minRunningTimeSeconds" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "title" : "LeaderboardFilterParamsDTO"
+    },
+    "LeaderboardGroupParamsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "groupBy" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "groupByFieldType" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          }
+        },
+        "groupByFieldAggregationMode" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          }
+        },
+        "openedGroups" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "LeaderboardGroupParamsDTO"
+    },
+    "LeaderboardSortParamsDTO" : {
+      "type" : "object",
+      "properties" : {
+        "sortBy" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "sortFieldType" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+          }
+        },
+        "sortFieldAggregationMode" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "last", "min", "max", "average", "variance", "auto" ]
+          }
+        },
+        "sortDirection" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "ascending", "descending" ]
+          }
+        }
+      },
+      "title" : "LeaderboardSortParamsDTO"
+    },
+    "LeaderboardViewColumnDTO" : {
+      "type" : "object",
+      "required" : [ "columnType", "id", "pinned", "width" ],
+      "properties" : {
+        "columnType" : {
+          "type" : "string",
+          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "numericParameters", "textParameters", "properties" ]
+        },
+        "id" : {
+          "type" : "string"
+        },
+        "pinned" : {
+          "type" : "boolean"
+        },
+        "width" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "aggregationMode" : {
+          "type" : "string",
+          "enum" : [ "last", "min", "max", "average", "variance" ]
+        },
+        "displayMode" : {
+          "type" : "string",
+          "enum" : [ "scientific", "decimal", "auto" ]
+        }
+      },
+      "title" : "LeaderboardViewColumnDTO"
+    },
+    "LeaderboardViewColumnListDTO" : {
+      "type" : "object",
+      "required" : [ "columns" ],
+      "properties" : {
+        "columns" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LeaderboardViewColumnDTO"
+          }
+        }
+      },
+      "title" : "LeaderboardViewColumnListDTO"
+    },
+    "LeaderboardViewDTO" : {
+      "type" : "object",
+      "required" : [ "columnList", "defaultView", "id", "name", "sortOptions", "suggestionsEnabled", "trashed" ],
+      "properties" : {
+        "columnList" : {
+          "$ref" : "#/definitions/LeaderboardViewColumnListDTO"
+        },
+        "defaultView" : {
+          "type" : "boolean"
+        },
+        "groupOptions" : {
+          "$ref" : "#/definitions/LeaderboardGroupParamsDTO"
         },
         "id" : {
           "type" : "string",
@@ -1943,50 +4796,197 @@
         },
         "name" : {
           "type" : "string"
+        },
+        "query" : {
+          "type" : "string"
+        },
+        "quickFilters" : {
+          "$ref" : "#/definitions/LeaderboardViewQuickFilterDTO"
+        },
+        "sortOptions" : {
+          "$ref" : "#/definitions/LeaderboardSortParamsDTO"
+        },
+        "suggestionsEnabled" : {
+          "type" : "boolean"
+        },
+        "trashed" : {
+          "type" : "boolean"
         }
       },
-      "title" : "NamedFilterDTO"
+      "title" : "LeaderboardViewDTO"
     },
-    "NamedFilterParamsDTO" : {
+    "LeaderboardViewListDTO" : {
       "type" : "object",
-      "required" : [ "filters", "name" ],
+      "required" : [ "views" ],
       "properties" : {
-        "filters" : {
-          "$ref" : "#/definitions/FilteringConditionsDTO"
+        "views" : {
+          "type" : "array",
+          "description" : "Leaderpoard views list",
+          "items" : {
+            "$ref" : "#/definitions/LeaderboardViewDTO"
+          }
+        }
+      },
+      "title" : "LeaderboardViewListDTO"
+    },
+    "LeaderboardViewQuickFilterDTO" : {
+      "type" : "object",
+      "properties" : {
+        "creationDateRangeEnd" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "creationDateRangeStart" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "owner" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "relativeTime" : {
+          "type" : "string",
+          "enum" : [ "lastDay", "lastWeek", "lastMonth", "lastQuarter" ]
+        },
+        "searchTerm" : {
+          "type" : "string"
+        },
+        "status" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "enum" : [ "running", "succeeded", "aborted", "failed" ]
+          }
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "LeaderboardViewQuickFilterDTO"
+    },
+    "LeaderboardViewSetDefaultDTO" : {
+      "type" : "object",
+      "required" : [ "projectIdentifier" ],
+      "properties" : {
+        "projectIdentifier" : {
+          "type" : "string"
+        },
+        "viewId" : {
+          "type" : "string",
+          "format" : "uuid"
+        }
+      },
+      "title" : "LeaderboardViewSetDefaultDTO"
+    },
+    "LeaderboardViewUpdateDTO" : {
+      "type" : "object",
+      "required" : [ "columnList", "defaultView", "name", "sortOptions", "suggestionsEnabled", "trashed" ],
+      "properties" : {
+        "columnList" : {
+          "$ref" : "#/definitions/LeaderboardViewColumnListDTO"
+        },
+        "defaultView" : {
+          "type" : "boolean"
+        },
+        "groupOptions" : {
+          "$ref" : "#/definitions/LeaderboardGroupParamsDTO"
         },
         "name" : {
           "type" : "string"
-        }
-      },
-      "title" : "NamedFilterParamsDTO"
-    },
-    "NamedFilterUpdateDTO" : {
-      "type" : "object",
-      "properties" : {
-        "filters" : {
-          "$ref" : "#/definitions/FilteringConditionsDTO"
         },
-        "name" : {
+        "query" : {
           "type" : "string"
+        },
+        "quickFilters" : {
+          "$ref" : "#/definitions/LeaderboardViewQuickFilterDTO"
+        },
+        "sortOptions" : {
+          "$ref" : "#/definitions/LeaderboardSortParamsDTO"
+        },
+        "suggestionsEnabled" : {
+          "type" : "boolean"
+        },
+        "trashed" : {
+          "type" : "boolean"
         }
       },
-      "title" : "NamedFilterUpdateDTO"
+      "title" : "LeaderboardViewUpdateDTO"
+    },
+    "LimitedChannelValuesDTO" : {
+      "type" : "object",
+      "required" : [ "channelId", "totalItemCount", "values" ],
+      "properties" : {
+        "channelId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "totalItemCount" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PointValueDTO"
+          }
+        }
+      },
+      "title" : "LimitedChannelValuesDTO"
     },
     "NewCheckpointDTO" : {
       "type" : "object",
       "required" : [ "path" ],
       "properties" : {
-        "description" : {
+        "path" : {
           "type" : "string"
         },
         "name" : {
           "type" : "string"
         },
-        "path" : {
+        "description" : {
           "type" : "string"
         }
       },
       "title" : "NewCheckpointDTO"
+    },
+    "NewLeaderboardViewDTO" : {
+      "type" : "object",
+      "required" : [ "columnList", "defaultView", "name", "sortOptions", "suggestionsEnabled", "trashed" ],
+      "properties" : {
+        "columnList" : {
+          "$ref" : "#/definitions/LeaderboardViewColumnListDTO"
+        },
+        "defaultView" : {
+          "type" : "boolean"
+        },
+        "groupOptions" : {
+          "$ref" : "#/definitions/LeaderboardGroupParamsDTO"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "query" : {
+          "type" : "string"
+        },
+        "quickFilters" : {
+          "$ref" : "#/definitions/LeaderboardViewQuickFilterDTO"
+        },
+        "sortOptions" : {
+          "$ref" : "#/definitions/LeaderboardSortParamsDTO"
+        },
+        "suggestionsEnabled" : {
+          "type" : "boolean"
+        },
+        "trashed" : {
+          "type" : "boolean"
+        }
+      },
+      "title" : "NewLeaderboardViewDTO"
     },
     "NewProjectChartDTO" : {
       "type" : "object",
@@ -2138,10 +5138,41 @@
       },
       "title" : "NotebooksDataDTO"
     },
-    "ParameterDTO" : {
+    "NqlQueryParamsDTO" : {
+      "type" : "object",
+      "required" : [ "query" ],
+      "properties" : {
+        "query" : {
+          "type" : "string"
+        }
+      },
+      "title" : "NqlQueryParamsDTO"
+    },
+    "OutputImageDTO" : {
+      "type" : "object",
+      "properties" : {
+        "description" : {
+          "type" : "string"
+        },
+        "imageUrl" : {
+          "type" : "string"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "thumbnailUrl" : {
+          "type" : "string"
+        }
+      },
+      "title" : "OutputImageDTO"
+    },
+    "Parameter" : {
       "type" : "object",
       "required" : [ "id", "name", "parameterType", "value" ],
       "properties" : {
+        "description" : {
+          "type" : "string"
+        },
         "id" : {
           "type" : "string",
           "format" : "uuid"
@@ -2157,7 +5188,64 @@
           "type" : "string"
         }
       },
+      "title" : "Parameter"
+    },
+    "ParameterDTO" : {
+      "type" : "object",
+      "required" : [ "id", "name", "parameterType", "value" ],
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "parameterType" : {
+          "type" : "string",
+          "enum" : [ "string", "double" ]
+        },
+        "value" : {
+          "type" : "string"
+        }
+      },
       "title" : "ParameterDTO"
+    },
+    "Point" : {
+      "type" : "object",
+      "required" : [ "timestampMillis", "y" ],
+      "properties" : {
+        "timestampMillis" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "x" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "y" : {
+          "$ref" : "#/definitions/Y"
+        }
+      },
+      "title" : "Point"
+    },
+    "PointValueDTO" : {
+      "type" : "object",
+      "required" : [ "timestampMillis", "y" ],
+      "properties" : {
+        "timestampMillis" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "x" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "y" : {
+          "$ref" : "#/definitions/YOutput"
+        }
+      },
+      "title" : "PointValueDTO"
     },
     "ProjectChartDTO" : {
       "type" : "object",
@@ -2259,10 +5347,10 @@
         "name" : {
           "type" : "string"
         },
-        "useFunction" : {
+        "useValue" : {
           "type" : "boolean"
         },
-        "useValue" : {
+        "useFunction" : {
           "type" : "boolean"
         }
       },
@@ -2290,68 +5378,293 @@
       },
       "title" : "ProjectChartUpdateDTO"
     },
-    "ProjectLeaderboardSettingColumnDTO" : {
+    "RichExperiment" : {
       "type" : "object",
-      "required" : [ "columnType", "id", "pinned", "width" ],
+      "required" : [ "channels", "channelsLastValues", "channelsSize", "componentsVersions", "description", "id", "name", "organizationId", "organizationName", "owner", "parameters", "paths", "projectId", "projectName", "properties", "relativePaths", "responding", "runningTime", "shortId", "state", "stateTransitions", "storageSize", "tags", "timeOfCreation", "trashed" ],
       "properties" : {
-        "columnType" : {
-          "type" : "string",
-          "enum" : [ "native", "numericChannels", "textChannels", "aliases", "parameters", "properties" ]
+        "channels" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Channel"
+          }
         },
-        "id" : {
+        "channelsLastValues" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ChannelWithValueDTO"
+          }
+        },
+        "channelsSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "checkpointId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "componentsVersions" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ComponentVersion"
+          }
+        },
+        "description" : {
           "type" : "string"
         },
-        "pinned" : {
+        "entrypoint" : {
+          "type" : "string"
+        },
+        "hostname" : {
+          "type" : "string"
+        },
+        "id" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "name" : {
+          "type" : "string"
+        },
+        "notebookId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "organizationId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "organizationName" : {
+          "type" : "string"
+        },
+        "owner" : {
+          "type" : "string"
+        },
+        "parameters" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Parameter"
+          }
+        },
+        "paths" : {
+          "$ref" : "#/definitions/ExperimentPaths"
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "projectName" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/KeyValueProperty"
+          }
+        },
+        "relativePaths" : {
+          "$ref" : "#/definitions/ExperimentPaths"
+        },
+        "responding" : {
           "type" : "boolean"
         },
-        "width" : {
+        "runningTime" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "shortId" : {
+          "type" : "string"
+        },
+        "state" : {
+          "type" : "string",
+          "enum" : [ "running", "succeeded", "aborted", "failed" ]
+        },
+        "stateTransitions" : {
+          "$ref" : "#/definitions/StateTransitionsDTO"
+        },
+        "storageSize" : {
+          "type" : "integer",
+          "format" : "int64"
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "timeOfCompletion" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "timeOfCreation" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "traceback" : {
+          "type" : "string"
+        },
+        "trashed" : {
+          "type" : "boolean"
+        }
+      },
+      "title" : "RichExperiment"
+    },
+    "SeriesViewDTO" : {
+      "type" : "object",
+      "required" : [ "channelId", "channelName", "downsampled", "experimentId", "experimentShortId", "firstPointIndex", "lastPointIndex", "maxY", "minY", "projectId", "projectName", "values" ],
+      "properties" : {
+        "channelId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "channelName" : {
+          "type" : "string"
+        },
+        "downsampled" : {
+          "type" : "boolean"
+        },
+        "experimentId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "experimentShortId" : {
+          "type" : "string"
+        },
+        "firstPointIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastPointIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "minY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "projectId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "projectName" : {
+          "type" : "string"
+        },
+        "values" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SeriesViewPointDTO"
+          }
+        }
+      },
+      "title" : "SeriesViewDTO"
+    },
+    "SeriesViewListDTO" : {
+      "type" : "object",
+      "required" : [ "elements" ],
+      "properties" : {
+        "elements" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SeriesViewDTO"
+          }
+        }
+      },
+      "title" : "SeriesViewListDTO"
+    },
+    "SeriesViewPointDTO" : {
+      "type" : "object",
+      "required" : [ "downsampled", "firstPointIndex", "lastPointIndex", "maxY", "minY", "timestamp", "x", "y" ],
+      "properties" : {
+        "downsampled" : {
+          "type" : "boolean"
+        },
+        "firstPointIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastPointIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "maxY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "minY" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "timestamp" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "x" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "y" : {
+          "type" : "number",
+          "format" : "double"
+        }
+      },
+      "title" : "SeriesViewPointDTO"
+    },
+    "SeriesViewRequestDTO" : {
+      "type" : "object",
+      "required" : [ "channelId", "experimentIdentifier" ],
+      "properties" : {
+        "channelId" : {
+          "type" : "string",
+          "format" : "uuid"
+        },
+        "experimentIdentifier" : {
+          "type" : "string"
+        },
+        "firstPointIndex" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "lastPointIndex" : {
           "type" : "integer",
           "format" : "int32"
         }
       },
-      "title" : "ProjectLeaderboardSettingColumnDTO"
+      "title" : "SeriesViewRequestDTO"
     },
-    "ProjectLeaderboardSettingsDTO" : {
+    "StateTransitionsDTO" : {
       "type" : "object",
-      "required" : [ "columns" ],
       "properties" : {
-        "columns" : {
-          "type" : "array",
-          "description" : "The columns for settings in order",
-          "items" : {
-            "$ref" : "#/definitions/ProjectLeaderboardSettingColumnDTO"
-          }
-        }
-      },
-      "title" : "ProjectLeaderboardSettingsDTO"
-    },
-    "StringFilterDTO" : {
-      "type" : "object",
-      "required" : [ "value", "verb" ],
-      "properties" : {
-        "value" : {
-          "type" : "string"
-        },
-        "verb" : {
+        "aborted" : {
           "type" : "string",
-          "enum" : [ "is", "isNot", "contains", "doesNotContain" ]
-        }
-      },
-      "title" : "StringFilterDTO"
-    },
-    "TagsFilterDTO" : {
-      "type" : "object",
-      "required" : [ "value", "verb" ],
-      "properties" : {
-        "value" : {
-          "type" : "string"
+          "format" : "date-time"
         },
-        "verb" : {
+        "failed" : {
           "type" : "string",
-          "enum" : [ "contains", "doesNotContain" ]
+          "format" : "date-time"
+        },
+        "running" : {
+          "type" : "string",
+          "format" : "date-time"
+        },
+        "succeeded" : {
+          "type" : "string",
+          "format" : "date-time"
         }
       },
-      "title" : "TagsFilterDTO"
+      "title" : "StateTransitionsDTO"
+    },
+    "StorageUsage" : {
+      "type" : "object",
+      "required" : [ "usage" ],
+      "properties" : {
+        "usage" : {
+          "type" : "integer",
+          "format" : "int64"
+        }
+      },
+      "title" : "StorageUsage"
     },
     "TimeDurationDTO" : {
       "type" : "object",
@@ -2399,6 +5712,89 @@
         }
       },
       "title" : "TrackingDataDTO"
+    },
+    "UpdateTagsParams" : {
+      "type" : "object",
+      "required" : [ "experimentIdentifiers", "tagsToAdd", "tagsToDelete" ],
+      "properties" : {
+        "experimentIdentifiers" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "tagsToAdd" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "tagsToDelete" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "UpdateTagsParams"
+    },
+    "UpdateTagsParamsDeprecatedDTO" : {
+      "type" : "object",
+      "required" : [ "experimentIds", "tagsToAdd", "tagsToDelete" ],
+      "properties" : {
+        "experimentIds" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        },
+        "tagsToAdd" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "tagsToDelete" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      },
+      "title" : "UpdateTagsParamsDeprecatedDTO"
+    },
+    "Y" : {
+      "type" : "object",
+      "properties" : {
+        "inputImageValue" : {
+          "$ref" : "#/definitions/InputImage"
+        },
+        "numericValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "textValue" : {
+          "type" : "string"
+        }
+      },
+      "title" : "Y"
+    },
+    "YOutput" : {
+      "type" : "object",
+      "properties" : {
+        "imageValue" : {
+          "$ref" : "#/definitions/OutputImageDTO"
+        },
+        "numericValue" : {
+          "type" : "number",
+          "format" : "double"
+        },
+        "textValue" : {
+          "type" : "string"
+        }
+      },
+      "title" : "YOutput"
     }
   }
 }

--- a/packages/neptune-extension/src/common/api/auth.ts
+++ b/packages/neptune-extension/src/common/api/auth.ts
@@ -54,10 +54,20 @@ class AuthClient {
     }));
 
     const accessToken = await exchangeApiTokenWithTimeout(localBackendClient, apiToken);
+    const oldDomainClientConfig = await this.backendClient.getClientConfig({
+      xNeptuneApiToken: apiToken,
+    });
+
+    const newDomainClientConfig = await this.backendClient.getClientConfig({
+      xNeptuneApiToken: apiToken,
+      alpha: String(true),
+    });
 
     return {
       apiTokenParsed,
       accessToken,
+      oldDomainClientConfig,
+      newDomainClientConfig,
     }
   }
 }

--- a/packages/neptune-extension/src/common/api/backend-client.ts
+++ b/packages/neptune-extension/src/common/api/backend-client.ts
@@ -5,6 +5,9 @@ import {
   ProjectListDTO,
 } from 'generated/backend-client/src';
 
+export * from 'generated/backend-client/src/apis';
+export * from 'generated/backend-client/src/models';
+
 import { getBasePath } from "./auth";
 import { updateTokenMiddleware } from "./update-token-middleware";
 

--- a/packages/neptune-extension/src/common/api/leaderboard-client.ts
+++ b/packages/neptune-extension/src/common/api/leaderboard-client.ts
@@ -89,6 +89,19 @@ class ApiWrapper {
     return this.clientAlpha;
   }
 
+
+  /**
+   * Warning: only notebooks related API is the same between version 1 and version 2
+   * Do not use version 2 for other endpoints (like experiments) until we fully migrate to version 2
+   */
+  getApi(projectVersion: number | undefined) {
+    if (projectVersion === 2) {
+      return this.clientAlpha;
+    }
+
+    return this.client;
+  }
+
   setBasePath(path: string) {
     // reinitialize client as there is no way to override base path after it was created
     this.client = this.createClient(path)

--- a/packages/neptune-extension/src/common/api/leaderboard-client.ts
+++ b/packages/neptune-extension/src/common/api/leaderboard-client.ts
@@ -62,9 +62,11 @@ class LeaderboardApi extends DefaultApi {
 
 class ApiWrapper {
   protected client: LeaderboardApi
+  protected clientAlpha: LeaderboardApi
 
   constructor() {
     this.client = this.createClient(getBasePath());
+    this.clientAlpha = this.createClient(getBasePath());
   }
 
   createClient(basePath: string) {
@@ -80,9 +82,18 @@ class ApiWrapper {
     return this.client;
   }
 
+  get alphaApi () {
+    return this.clientAlpha;
+  }
+
   setBasePath(path: string) {
     // reinitialize client as there is no way to override base path after it was created
     this.client = this.createClient(path)
+  }
+
+  setBasePathAlpha(path: string) {
+    // reinitialize client as there is no way to override base path after it was created
+    this.clientAlpha = this.createClient(path);
   }
 }
 

--- a/packages/neptune-extension/src/common/api/leaderboard-client.ts
+++ b/packages/neptune-extension/src/common/api/leaderboard-client.ts
@@ -6,6 +6,9 @@ import {
 } from 'generated/leaderboard-client/src';
 import * as runtime from "generated/leaderboard-client/src/runtime";
 
+export * from 'generated/leaderboard-client/src/apis';
+export * from 'generated/leaderboard-client/src/models';
+
 import { getBasePath } from "./auth";
 import { updateTokenMiddleware } from "./update-token-middleware";
 

--- a/packages/neptune-extension/src/common/components/checkout-modal/CheckoutModal.tsx
+++ b/packages/neptune-extension/src/common/components/checkout-modal/CheckoutModal.tsx
@@ -26,6 +26,7 @@ import { getNotebookState } from 'common/state/notebook/selectors'
 import { addNotification } from 'common/state/notifications/actions';
 
 import { findNonExistantPath } from 'common/utils/path';
+import { createProjectIdentifier } from 'common/utils/project';
 
 import {
   fetchProjectOptions,
@@ -53,21 +54,24 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({
   const initialProjectId = () => notebook ? notebook.projectId : getDefaultProjectId();
   const initialNotebookId = notebook ? notebook.id : undefined;
 
-  const [ projectId, projectLabel, projectInputProps, projectMetaProps ] = useSelectInputValue(
+  const [ projectId, selectedProject, projectInputProps, projectMetaProps ] = useSelectInputValue(
     initialProjectId,
     () => fetchProjectOptions('readable'),
+    option => option.id,
     []
   );
 
-  const [ notebookId, notebookLabel, notebookInputProps, notebookMetaProps ] = useSelectInputValue(
+  const [ notebookId, selectedNotebookOption, notebookInputProps, notebookMetaProps ] = useSelectInputValue(
     initialNotebookId,
     () => fetchNotebookOptions(projectId),
+    (option => option[0]),
     [projectId]
   );
 
-  const [ checkpointId, checkpointLabel, checkpointInputProps, checkpointMetaProps ] = useSelectInputValue(
+  const [ checkpointId, selectedCheckpointOption, checkpointInputProps, checkpointMetaProps ] = useSelectInputValue(
     undefined,
     () => fetchCheckpointOptions(notebookId),
+    (option => option[0]),
     [notebookId]
   );
 
@@ -118,6 +122,7 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({
           <SelectInput
             className={block('input')}
             placeholder="No projects to select"
+            getLabel={option => createProjectIdentifier(option.organizationName, option.name)}
             {...projectInputProps}
             {...projectMetaProps}
           />
@@ -128,6 +133,7 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({
           <SelectInput
             className={block('input')}
             placeholder="No notebooks to select"
+            getLabel={option => option[1]}
             {...notebookInputProps}
             {...notebookMetaProps}
           />
@@ -138,6 +144,7 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({
           <SelectInput
             className={block('input')}
             placeholder="No checkpoints to select"
+            getLabel={option => option[1]}
             {...checkpointInputProps}
             {...checkpointMetaProps}
           />

--- a/packages/neptune-extension/src/common/components/checkout-modal/CheckoutModal.tsx
+++ b/packages/neptune-extension/src/common/components/checkout-modal/CheckoutModal.tsx
@@ -61,29 +61,32 @@ const CheckoutModal: React.FC<CheckoutModalProps> = ({
     []
   );
 
+  // todo upgrade typescript so we can use optional chaining (obj?.smth)
+  const selectedProjectVersion: number | undefined = selectedProject && selectedProject.version;
+
   const [ notebookId, selectedNotebookOption, notebookInputProps, notebookMetaProps ] = useSelectInputValue(
     initialNotebookId,
-    () => fetchNotebookOptions(projectId),
+    () => fetchNotebookOptions(projectId, selectedProjectVersion),
     (option => option[0]),
-    [projectId]
+    [projectId, selectedProjectVersion]
   );
 
   const [ checkpointId, selectedCheckpointOption, checkpointInputProps, checkpointMetaProps ] = useSelectInputValue(
     undefined,
-    () => fetchCheckpointOptions(notebookId),
+    () => fetchCheckpointOptions(selectedProject && selectedProject.version, notebookId,),
     (option => option[0]),
-    [notebookId]
+    [notebookId, selectedProjectVersion]
   );
 
   const dispatch = useDispatch();
 
   async function checkoutNotebook() {
-    if (checkpointId === undefined || notebookId === undefined || projectId === undefined) {
+    if (checkpointId === undefined || notebookId === undefined || projectId === undefined || selectedProject === undefined) {
       return;
     }
 
-    const notebook = await leaderboardClient.api.getNotebook({ id: notebookId });
-    const content = await leaderboardClient.api.getCheckpointContent({ id: checkpointId });
+    const notebook = await leaderboardClient.getApi(selectedProjectVersion).getNotebook({ id: notebookId });
+    const content = await leaderboardClient.getApi(selectedProjectVersion).getCheckpointContent({ id: checkpointId });
 
     setDefaultProjectId(projectId);
 

--- a/packages/neptune-extension/src/common/components/input/SelectInput.tsx
+++ b/packages/neptune-extension/src/common/components/input/SelectInput.tsx
@@ -3,23 +3,27 @@ import Select from './Select';
 import ValidationWrapper from "../validation-wrapper/ValidationWrapper";
 import ValidationIcon from "../validation-icon/ValidationIcon";
 
-interface SelectInputProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+interface SelectInputProps<T> extends React.SelectHTMLAttributes<HTMLSelectElement> {
   valid?: boolean,
   loading?: boolean,
-  options: string[][]
+  options: T[]
+  getKey: (option: T) => string
+  getLabel: (option: T) => string
   placeholder?: string
 }
 
-const SelectInput: React.FC<SelectInputProps> = ({
+function SelectInput<T>({
   value,
   disabled,
   valid,
   loading,
   options,
+  getKey,
+  getLabel,
   onChange,
   placeholder,
   ...rest
-}) => {
+}: SelectInputProps<T>): React.ReactElement {
   const endStatus = valid ? 'success' : 'error';
   const status = loading ? 'pending' : endStatus;
   const isDisabled = disabled || status === 'pending' || options.length === 0;
@@ -36,18 +40,18 @@ const SelectInput: React.FC<SelectInputProps> = ({
       >
         {showPlaceholder ? (
           <option value="" hidden>{ placeholder }</option>
-        ) : options.map(([ key, value ]) => (
+        ) : options.map((option) => (
           <option
-            key={key}
-            value={key}
-            children={value}
+            key={getKey(option)}
+            value={getKey(option)}
+            children={getLabel(option)}
           />
         ))}
       </Select>
       <ValidationIcon status={status} />
     </ValidationWrapper>
   );
-};
+}
 
 export default SelectInput;
 

--- a/packages/neptune-extension/src/common/components/notifications/renderers/CheckpointSuccessfulNotification.tsx
+++ b/packages/neptune-extension/src/common/components/notifications/renderers/CheckpointSuccessfulNotification.tsx
@@ -3,26 +3,24 @@ import React from 'react';
 import {useSelector} from "react-redux";
 
 // App
+import {AppState} from 'common/state/reducers';
 import {CheckpointSuccessful} from 'common/state/notifications/actions';
 import Toast from 'common/components/toast/Toast';
-import {NotificationLink} from "./link/NotificationLink";
+import {NotificationLink} from './link/NotificationLink';
 import {createCheckpointUrl} from 'common/utils/createCheckpointUrl';
-import {getConfigurationState} from 'common/state/configuration/selectors';
+import {getApplicationUrl} from 'common/state/configuration/selectors';
 
 // Module
 type Props = CheckpointSuccessful & { onClose: () => void };
 
 export const CheckpointSuccessfulNotification: React.FC<Props> = ({ data, onClose }) => {
-  const {
-    apiTokenParsed
-  } = useSelector(getConfigurationState);
-
-  if (!apiTokenParsed) {
+  const applicationUrl = useSelector((state: AppState) => getApplicationUrl(state, data.projectVersion));
+  if (!applicationUrl) {
     return null;
   }
 
   const url = createCheckpointUrl({
-    api_address: apiTokenParsed.api_address,
+    applicationUrl,
     ...data
   });
 

--- a/packages/neptune-extension/src/common/components/upload-modal/UploadModal.tsx
+++ b/packages/neptune-extension/src/common/components/upload-modal/UploadModal.tsx
@@ -125,7 +125,7 @@ const UploadModal: React.FC<UploadModalProps> = ({
       );
     } else {
       returnValue = await dispatch(
-        uploadCheckpoint(projectIdentifier, metadata.notebookId, checkpointMeta, content),
+        uploadCheckpoint(projectIdentifier, selectedProject.version, metadata.notebookId, checkpointMeta, content),
       );
     }
     if (returnValue) {

--- a/packages/neptune-extension/src/common/components/upload-modal/UploadModal.tsx
+++ b/packages/neptune-extension/src/common/components/upload-modal/UploadModal.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { AnyAction } from 'redux';
-import { ThunkDispatch } from "redux-thunk";
 
 import { bemBlock} from "common/utils/bem";
 import { NotebookDTO } from 'generated/leaderboard-client/src/models';
@@ -23,22 +21,22 @@ import Input from 'common/components/input/Input';
 import Textarea from 'common/components/input/Textarea';
 import Button from 'common/components/button/Button';
 import ButtonWithLoading from 'common/components/button-with-loading/ButtonWithLoading';
-import ValidationIcon from "common/components/validation-icon/ValidationIcon";
-import ValidationWrapper from "common/components/validation-wrapper/ValidationWrapper";
-import Warning from "common/components/warning/Warning";
-import ModalHeader from "common/components/modal/ModalHeader";
+import ValidationIcon from 'common/components/validation-icon/ValidationIcon';
+import ValidationWrapper from 'common/components/validation-wrapper/ValidationWrapper';
+import Warning from 'common/components/warning/Warning';
+import ModalHeader from 'common/components/modal/ModalHeader';
 
 import { getConfigurationState } from 'common/state/configuration/selectors';
 import {
   getNotebookState,
   getNotebookLoadingState,
 } from 'common/state/notebook/selectors'
-import useSelectInputValue from "common/hooks/useSelectInputValue";
-import {fetchProjectOptions} from "common/utils/checkout";
-import SelectInput from "common/components/input/SelectInput";
+import useSelectInputValue from 'common/hooks/useSelectInputValue';
+import {fetchProjectOptions} from 'common/utils/checkout';
+import {createProjectIdentifier} from 'common/utils/project';
+import SelectInput from 'common/components/input/SelectInput';
 
 import './UploadModal.less';
-import {createProjectIdentifier} from "../../utils/project";
 
 interface UploadModalProps {
   platformNotebook: PlatformNotebook

--- a/packages/neptune-extension/src/common/hooks/neptuneComm.ts
+++ b/packages/neptune-extension/src/common/hooks/neptuneComm.ts
@@ -15,7 +15,8 @@ async function handleCreateCheckpoint(platformNotebook: PlatformNotebook, checkp
   const content = await platformNotebook.saveWorkingCopyAndGetContent();
   log('saved checkpoint', content);
 
-  await leaderboardClient.api.uploadCheckpointContent({
+  const metadata = platformNotebook.getMetadata();
+  await leaderboardClient.getApi(metadata.projectVersion).uploadCheckpointContent({
     id: checkpointId,
     content,
   });

--- a/packages/neptune-extension/src/common/hooks/notebook.ts
+++ b/packages/neptune-extension/src/common/hooks/notebook.ts
@@ -29,7 +29,7 @@ export function loadInitialNotebook(platformNotebook: PlatformNotebook) {
       return;
     }
 
-    dispatch(fetchNotebook(metadata.notebookId));
-  }, [isApiTokenValid, metadata.notebookId])
+    dispatch(fetchNotebook(metadata.projectVersion, metadata.notebookId));
+  }, [isApiTokenValid, metadata.notebookId, metadata.projectVersion])
 }
 

--- a/packages/neptune-extension/src/common/state/configuration/actions.ts
+++ b/packages/neptune-extension/src/common/state/configuration/actions.ts
@@ -29,4 +29,17 @@ export function setTokenUsername(username?: string) {
   } as const;
 }
 
-export type ConfigurationActions = ReturnType<typeof setApiToken | typeof setApiTokenValid | typeof setTokenUsername>
+type ClientConfig = {apiUrl: string, applicationUrl: string}
+export function setClientConfig(clientConfig: { newDomain: ClientConfig, oldDomain: ClientConfig }) {
+  return {
+    type: 'CLIENT_CONFIG_SET',
+    payload: clientConfig,
+  } as const;
+}
+
+export type ConfigurationActions = ReturnType<
+  | typeof setApiToken
+  | typeof setApiTokenValid
+  | typeof setTokenUsername
+  | typeof setClientConfig
+>

--- a/packages/neptune-extension/src/common/state/configuration/reducer.ts
+++ b/packages/neptune-extension/src/common/state/configuration/reducer.ts
@@ -6,6 +6,10 @@ interface ConfigurationState {
   apiTokenParsed?: ApiTokenParsed
   isApiTokenValid?: boolean
   inferredUsername?: string
+  oldDomainApiUrl?: string
+  newDomainApiUrl?: string
+  oldDomainApplicationUrl?: string
+  newDomainApplicationUrl?: string
 }
 
 const dummyInitialState: ConfigurationState = {};
@@ -48,6 +52,20 @@ export function configurationReducer(state: ConfigurationState = dummyInitialSta
       return {
         ...state,
         isApiTokenValid: action.payload.valid,
+      }
+    }
+
+    case "CLIENT_CONFIG_SET": {
+      const {
+        newDomain,
+        oldDomain,
+      } = action.payload;
+      return {
+        ...state,
+        newDomainApiUrl: newDomain.apiUrl,
+        newDomainApplicationUrl: newDomain.applicationUrl,
+        oldDomainApiUrl: oldDomain.apiUrl,
+        oldDomainApplicationUrl: oldDomain.applicationUrl,
       }
     }
 

--- a/packages/neptune-extension/src/common/state/configuration/selectors.ts
+++ b/packages/neptune-extension/src/common/state/configuration/selectors.ts
@@ -3,3 +3,13 @@ import {AppState} from "common/state/reducers";
 export function getConfigurationState(state: AppState) {
   return state.configuration;
 }
+
+export function getApplicationUrl(state: AppState, domainVersion: number | undefined) {
+  const configuration = getConfigurationState(state);
+
+  if (domainVersion === 2) {
+    return configuration.newDomainApplicationUrl;
+  }
+
+  return configuration.oldDomainApplicationUrl;
+}

--- a/packages/neptune-extension/src/common/state/notebook/actions.ts
+++ b/packages/neptune-extension/src/common/state/notebook/actions.ts
@@ -74,6 +74,7 @@ export const uploadNotebook = (
         type: 'checkpoint-successful',
         data: {
           projectIdentifier,
+          projectVersion,
           notebookId: notebook.id,
         }
       }));
@@ -122,6 +123,7 @@ export const uploadCheckpoint = (projectIdentifier: string, projectVersion: numb
         type: 'checkpoint-successful',
         data: {
           projectIdentifier,
+          projectVersion,
           notebookId,
           checkpointId: checkpoint.id,
         }

--- a/packages/neptune-extension/src/common/state/notebook/actions.ts
+++ b/packages/neptune-extension/src/common/state/notebook/actions.ts
@@ -49,6 +49,7 @@ interface CheckpointMetadata {
 
 export const uploadNotebook = (
   projectIdentifier: string,
+  projectVersion: number | undefined,
   checkpointMeta: CheckpointMetadata,
   content: any,
   platformNotebook: PlatformNotebook,
@@ -62,7 +63,10 @@ export const uploadNotebook = (
       log('uploadNotebook, empty notebook created', notebook);
       await requestCheckpoint(notebook.id, checkpointMeta, content);
       log('uploadNotebook, checkpoint created, content uploaded');
-      await platformNotebook.saveNotebookId(notebook.id);
+      await platformNotebook.setMetadata({
+        notebookId: notebook.id,
+        projectVersion,
+      });
 
       dispatch(uploadNotebookSuccess(notebook));
 

--- a/packages/neptune-extension/src/common/state/notebook/actions.ts
+++ b/packages/neptune-extension/src/common/state/notebook/actions.ts
@@ -9,13 +9,13 @@ import { logger } from 'common/utils/logger';
 
 const log = logger.extend('notebook-actions');
 
-export const fetchNotebook = (notebookId: string): ThunkAction<Promise<NotebookDTO | void>, {}, {}, NotebookActions> => {
+export const fetchNotebook = (projectVersion: number | undefined, notebookId: string): ThunkAction<Promise<NotebookDTO | void>, {}, {}, NotebookActions> => {
   return async (dispatch: ThunkDispatch<{}, {}, AnyAction>) => {
     log('fetchNotebook', notebookId);
     dispatch(fetchNotebookRequest());
 
     try {
-      const notebook = await leaderboardClient.api.getNotebook({ id: notebookId });
+      const notebook = await leaderboardClient.getApi(projectVersion).getNotebook({ id: notebookId });
 
       dispatch(fetchNotebookSuccess(notebook));
       log('fetchNotebook success', notebook);
@@ -59,9 +59,9 @@ export const uploadNotebook = (
     dispatch(uploadNotebookRequest());
 
     try {
-      const notebook = await leaderboardClient.api.createNotebook({projectIdentifier});
+      const notebook = await leaderboardClient.getApi(projectVersion).createNotebook({projectIdentifier});
       log('uploadNotebook, empty notebook created', notebook);
-      await requestCheckpoint(notebook.id, checkpointMeta, content);
+      await requestCheckpoint(projectVersion, notebook.id, checkpointMeta, content);
       log('uploadNotebook, checkpoint created, content uploaded');
       await platformNotebook.setMetadata({
         notebookId: notebook.id,
@@ -106,7 +106,7 @@ function uploadNotebookFailed() {
   return { type: 'NOTEBOOK_UPLOAD_FAILED' } as const;
 }
 
-export const uploadCheckpoint = (projectIdentifier: string, notebookId: string, checkpointMeta: CheckpointMetadata, content: any)
+export const uploadCheckpoint = (projectIdentifier: string, projectVersion: number | undefined, notebookId: string, checkpointMeta: CheckpointMetadata, content: any)
   : ThunkAction<Promise<CheckpointDTO | void>, AppState, {}, NotebookActions> => {
   return async (dispatch: ThunkDispatch<{}, {}, AnyAction>) => {
     log('uploadCheckpoint', projectIdentifier, notebookId, checkpointMeta, content);
@@ -114,8 +114,8 @@ export const uploadCheckpoint = (projectIdentifier: string, notebookId: string, 
     dispatch(uploadCheckpointRequest());
 
     try {
-      const checkpoint = await requestCheckpoint(notebookId, checkpointMeta, content);
-      await dispatch(fetchNotebook(notebookId));
+      const checkpoint = await requestCheckpoint(projectVersion, notebookId, checkpointMeta, content);
+      await dispatch(fetchNotebook(projectVersion, notebookId));
       dispatch(uploadCheckpointSuccess(checkpoint));
       log('uploadCheckpoint success');
       dispatch(addNotification({
@@ -169,16 +169,16 @@ export type NotebookActions = ReturnType<
   | typeof uploadCheckpointFailed
 >
 
-async function requestCheckpoint(notebookId: string, checkpointMeta: CheckpointMetadata, content: any) {
+async function requestCheckpoint(projectVersion: number | undefined, notebookId: string, checkpointMeta: CheckpointMetadata, content: any) {
   log('requestCheckpoint', notebookId, checkpointMeta, content);
-  const checkpoint = await leaderboardClient.api.createEmptyCheckpoint({
+  const checkpoint = await leaderboardClient.getApi(projectVersion).createEmptyCheckpoint({
     notebookId,
     checkpoint: checkpointMeta,
   });
 
   log('requestCheckpoint, empty checkpoint created', checkpoint);
 
-  await leaderboardClient.api.uploadCheckpointContent({
+  await leaderboardClient.getApi(projectVersion).uploadCheckpointContent({
     id: checkpoint.id,
     content,
   });

--- a/packages/neptune-extension/src/common/state/notifications/actions.ts
+++ b/packages/neptune-extension/src/common/state/notifications/actions.ts
@@ -11,7 +11,9 @@ interface NotificationWithData<T, D> extends BaseNotification<T> {
 
 export type SuccessNotification = NotificationWithData<'success', string>
 export type ErrorNotification = NotificationWithData<'error', string>
-export type CheckpointSuccessful = NotificationWithData<'checkpoint-successful', CheckpointPathArgs>
+export type CheckpointSuccessful = NotificationWithData<
+  'checkpoint-successful', CheckpointPathArgs & {projectVersion: number | undefined}
+>
 export type UpgradeAvailable = BaseNotification<'upgrade-available'>
 
 export type Notification = SuccessNotification | ErrorNotification| CheckpointSuccessful | UpgradeAvailable

--- a/packages/neptune-extension/src/common/utils/checkout.ts
+++ b/packages/neptune-extension/src/common/utils/checkout.ts
@@ -1,4 +1,7 @@
-import {backendClient} from 'common/api/backend-client';
+import {
+  backendClient,
+  ProjectWithRoleDTO
+} from 'common/api/backend-client';
 import {leaderboardClient} from 'common/api/leaderboard-client';
 
 import moment from 'moment';
@@ -8,7 +11,7 @@ import {ListNotebooksSortByEnum, ListNotebooksSortDirectionEnum} from 'generated
 
 type ProjectOptionsFetchMode = 'readable' | 'writable'
 
-export async function fetchProjectOptions(mode: ProjectOptionsFetchMode) {
+export async function fetchProjectOptions(mode: ProjectOptionsFetchMode): Promise<ProjectWithRoleDTO[]> {
   const { entries } = mode === 'readable'
     ? await backendClient.api.listProjects({
         userRelation: 'any',
@@ -18,10 +21,12 @@ export async function fetchProjectOptions(mode: ProjectOptionsFetchMode) {
 
 
   return entries
-    .map(entry =>
-      [ entry.id, createProjectIdentifier(entry.organizationName, entry.name) ]
-    )
-    .sort((a, b) => naturalStringComparator(a[1], b[1]));
+    .sort((left, right) => {
+      const leftIdentifier = createProjectIdentifier(left.organizationName, left.name)
+      const rightIdentifier = createProjectIdentifier(right.organizationName, right.name)
+
+      return naturalStringComparator(leftIdentifier, rightIdentifier);
+    })
 }
 
 export async function fetchNotebookOptions(projectIdentifier?: string) {

--- a/packages/neptune-extension/src/common/utils/checkout.ts
+++ b/packages/neptune-extension/src/common/utils/checkout.ts
@@ -29,12 +29,12 @@ export async function fetchProjectOptions(mode: ProjectOptionsFetchMode): Promis
     })
 }
 
-export async function fetchNotebookOptions(projectIdentifier?: string) {
+export async function fetchNotebookOptions(projectIdentifier?: string, projectVersion?: number) {
   if (projectIdentifier === undefined) {
     return [];
   }
 
-  const { entries } = await leaderboardClient.api.listNotebooks({
+  const { entries } = await leaderboardClient.getApi(projectVersion).listNotebooks({
     projectIdentifier,
     sortBy: ListNotebooksSortByEnum.UpdateTime,
     sortDirection: ListNotebooksSortDirectionEnum.Descending,
@@ -45,12 +45,12 @@ export async function fetchNotebookOptions(projectIdentifier?: string) {
   );
 }
 
-export async function fetchCheckpointOptions(notebookId?: string) {
+export async function fetchCheckpointOptions(projectVersion: number | undefined, notebookId?: string) {
   if (notebookId === undefined) {
     return [];
   }
 
-  const { entries } = await leaderboardClient.api.listCheckpoints({ notebookId });
+  const { entries } = await leaderboardClient.getApi(projectVersion).listCheckpoints({ notebookId });
   return entries.map(entry =>
     [ entry.id, `${entry.name ? entry.name : '(unnamed)'} - ${moment(entry.creationTime).format('YYYY/MM/DD HH:mm:ss')}` ]
   );

--- a/packages/neptune-extension/src/common/utils/createCheckpointUrl.ts
+++ b/packages/neptune-extension/src/common/utils/createCheckpointUrl.ts
@@ -6,7 +6,7 @@ export interface CheckpointPathArgs {
 }
 
 interface UrlArgs extends CheckpointPathArgs {
-  api_address: string
+  applicationUrl: string
 }
 
 export function createCheckpointPath({
@@ -27,7 +27,7 @@ export function createCheckpointPath({
 }
 
 export function createCheckpointUrl(options: UrlArgs):string | undefined {
-  if (options.api_address) {
-    return `${options.api_address}${createCheckpointPath(options)}`;
+  if (options.applicationUrl) {
+    return `${options.applicationUrl}${createCheckpointPath(options)}`;
   }
 }

--- a/packages/neptune-extension/src/labextension/utils/notebook.ts
+++ b/packages/neptune-extension/src/labextension/utils/notebook.ts
@@ -5,13 +5,15 @@ import { Contents, Kernel, KernelMessage, Session } from '@jupyterlab/services';
 
 import { get } from 'lodash';
 import {
-  PlatformNotebook,
+  EditablePlatformNotebookMetadata,
   NeptuneClientMsg,
+  PlatformNotebook,
 } from "types/platform";
 import { logger } from 'common/utils/logger';
 
 interface NeptuneContextMetadata {
   notebookId?: string
+  projectVersion?: number
 }
 
 const log = logger.extend('platform-notebook');
@@ -40,21 +42,23 @@ class Notebook implements PlatformNotebook {
   getMetadata() {
     const neptuneMetadata = this.context.model.metadata.get('neptune');
     const notebookId = get(neptuneMetadata, 'notebookId');
+    const projectVersion = get(neptuneMetadata, 'projectVersion');
 
     return {
       path: this.context.path,
       notebookId,
+      projectVersion,
     };
   };
 
-  async saveNotebookId(notebookId: string) {
-    const metadata = this.context.model.metadata;
+  async setMetadata(metadata: EditablePlatformNotebookMetadata) {
+    const contextMetadata = this.context.model.metadata;
 
-    const neptuneMetadata = metadata.has('neptune')
-      ? metadata.get('neptune') as NeptuneContextMetadata
+    const neptuneMetadata = contextMetadata.has('neptune')
+      ? contextMetadata.get('neptune') as NeptuneContextMetadata
       : {};
 
-    metadata.set('neptune', { ...neptuneMetadata, notebookId });
+    contextMetadata.set('neptune', { ...neptuneMetadata, ...metadata });
 
     return this.context.save();
   };

--- a/packages/neptune-extension/src/nbextension/utils/notebook.ts
+++ b/packages/neptune-extension/src/nbextension/utils/notebook.ts
@@ -1,7 +1,8 @@
 import { get } from 'lodash';
 import {
-  PlatformNotebook,
+  EditablePlatformNotebookMetadata,
   NeptuneClientMsg,
+  PlatformNotebook,
 } from 'types/platform';
 
 import Jupyter from 'base/js/namespace';
@@ -48,17 +49,20 @@ class Notebook implements PlatformNotebook {
       notebook_path,
     } = notebook;
 
-    const notebookId = get(notebook, 'metadata.neptune.notebookId');
+    const notebookId: string | undefined = get(notebook, 'metadata.neptune.notebookId');
+    const projectVersion: number | undefined = get(notebook, 'metadata.neptune.projectVersion');
 
     return {
       path: notebook_path,
       notebookId,
+      projectVersion,
     };
   }
 
-  async saveNotebookId(notebookId: string) {
+  async setMetadata(metadata: EditablePlatformNotebookMetadata) {
     Jupyter.notebook.metadata.neptune = {
-      notebookId,
+      notebookId: metadata.notebookId,
+      projectVersion: metadata.projectVersion,
     };
     Jupyter.notebook.save_checkpoint();
   }

--- a/packages/neptune-extension/src/types/jupyter.d.ts
+++ b/packages/neptune-extension/src/types/jupyter.d.ts
@@ -57,6 +57,7 @@ interface NbMetadata {
 
 interface NbNeptuneMetadata {
   notebookId?: string
+  projectVersion?: number | undefined
 }
 
 interface NbKernel {

--- a/packages/neptune-extension/src/types/platform.ts
+++ b/packages/neptune-extension/src/types/platform.ts
@@ -1,8 +1,12 @@
 
 export interface PlatformNotebookMetadata {
   path: string
+  // 1 - old domain, 2 - new domain, optional for compatibility with old notebook files
+  projectVersion?: number
   notebookId?: string
 }
+
+export type EditablePlatformNotebookMetadata = Pick<PlatformNotebookMetadata, 'notebookId' | 'projectVersion'>
 
 export interface PlatformNotebook {
   /*
@@ -11,7 +15,7 @@ export interface PlatformNotebook {
    */
   saveWorkingCopyAndGetContent: () => Promise<any>
   getMetadata: () => PlatformNotebookMetadata
-  saveNotebookId: (notebookId: string) => Promise<void>
+  setMetadata: (metadata: EditablePlatformNotebookMetadata) => Promise<void>
   executeKernelCode: (code: string) => void
   registerNeptuneMessageListener: (callback: (msg: NeptuneClientMsg) => void) => void
   saveNotebookAndOpenInNewWindow: (path: string, content: any) => void


### PR DESCRIPTION
This PR allows using neptune-notebooks in v1 (old) and v2 (new) domain of Neptune.

Users can use this extension and upload/checkout notebooks to/from projects created in the old and the new domain.