### PR TITLE
Fix API token validation using wrong instance of backendClient

### DIFF
--- a/packages/neptune-extension/src/common/api/auth.ts
+++ b/packages/neptune-extension/src/common/api/auth.ts
@@ -54,11 +54,11 @@ class AuthClient {
     }));
 
     const accessToken = await exchangeApiTokenWithTimeout(localBackendClient, apiToken);
-    const oldDomainClientConfig = await this.backendClient.getClientConfig({
+    const oldDomainClientConfig = await localBackendClient.getClientConfig({
       xNeptuneApiToken: apiToken,
     });
 
-    const newDomainClientConfig = await this.backendClient.getClientConfig({
+    const newDomainClientConfig = await localBackendClient.getClientConfig({
       xNeptuneApiToken: apiToken,
       alpha: String(true),
     });


### PR DESCRIPTION
# Reproduction steps

1. Empty local storage
2. Paste valid API token in Configure window

Result: API token validation fails.
Expected: API token validation is succesful.